### PR TITLE
Add mark all notifications read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,6 @@ jobs:
 
       - name: Run panel source tests
         run: tests/panel-source-test.sh
+
+      - name: Run service source tests
+        run: tests/service-source-test.sh

--- a/Panel.qml
+++ b/Panel.qml
@@ -81,6 +81,7 @@ Panel {
     openUrl(selectedTarget.row.url)
   }
   function markSelectedRead() {
+    if (github.marking) return
     if (selectedTarget && selectedTarget.kind === "notification") github.markNotificationRead(String(selectedTarget.row.id || ""))
   }
   function scrollItemIntoView(item) {
@@ -310,7 +311,7 @@ Panel {
             actionText: "Mark all read"
             actionBusyText: "Marking…"
             actionEnabled: github.state === "ready"
-            actionBusy: github.markingAllNotifications
+            actionBusy: github.marking
             onActionTriggered: github.markAllNotificationsRead()
           }
 
@@ -614,6 +615,11 @@ Panel {
 
     function disarmAction() { section.actionArmed = false; actionArmTimer.stop() }
 
+    // An armed confirmation must not outlive the button being clickable, or it
+    // would fire on the first click once the button comes back.
+    onActionBusyChanged: if (section.actionBusy) section.disarmAction()
+    onActionEnabledChanged: if (!section.actionEnabled) section.disarmAction()
+
     width: parent ? parent.width : 0
     spacing: Style.space(8)
 
@@ -665,6 +671,13 @@ Panel {
         onClicked: section.toggleExpanded()
       }
       Button {
+        id: actionButton
+        // The confirm and busy labels are shorter than the idle one. Letting the
+        // button shrink would slide its neighbours under a pointer that is about
+        // to click again, so the widest label seen so far sets the width.
+        property real reservedWidth: 0
+        onImplicitWidthChanged: reservedWidth = Math.max(reservedWidth, implicitWidth)
+        width: Math.max(reservedWidth, implicitWidth)
         visible: sectionFooter.showAction
         enabled: !section.actionBusy
         text: section.actionBusy ? section.actionBusyText : (section.actionArmed ? section.actionConfirmText : section.actionText)
@@ -764,7 +777,7 @@ Panel {
       }
       PanelActionButton {
         visible: linkRow.showReadAction
-        enabled: github.markingNotificationId === ""
+        enabled: !github.marking
         iconText: github.markingNotificationId === linkRow.notificationId ? "󰑐" : "󰄬"
         tooltipText: "Mark this notification read (M)"
         foreground: root.foreground

--- a/Panel.qml
+++ b/Panel.qml
@@ -81,7 +81,7 @@ Panel {
     openUrl(selectedTarget.row.url)
   }
   function markSelectedRead() {
-    if (github.marking) return
+    if (github.loading || github.marking) return
     if (selectedTarget && selectedTarget.kind === "notification") github.markNotificationRead(String(selectedTarget.row.id || ""))
   }
   function scrollItemIntoView(item) {
@@ -264,6 +264,7 @@ Panel {
             visible: github.notificationActionStatus !== ""
             width: parent.width
             text: github.notificationActionStatus
+            textFormat: Text.PlainText
             color: root.dim
             font.family: root.fontFamily
             font.pixelSize: Style.font.bodySmall
@@ -291,6 +292,7 @@ Panel {
                 if (github.warnings.length > 1) summary += " · " + (github.warnings.length - 1) + " more"
                 return summary
               }
+              textFormat: Text.PlainText
               color: github.state === "ready" ? root.dim : root.urgent
               font.family: root.fontFamily
               font.pixelSize: Style.font.bodySmall
@@ -310,9 +312,11 @@ Panel {
             delegateComponent: notificationDelegate
             actionText: "Mark all read"
             actionBusyText: "Marking…"
-            actionEnabled: github.state === "ready"
+            actionEnabled: github.state === "ready" && !github.loading
             actionBusy: github.marking
-            onActionTriggered: github.markAllNotificationsRead()
+            actionRevision: github.notificationsRevision
+            actionPrepare: function() { return github.prepareMarkAllNotificationsRead() }
+            onActionTriggered: function(prepared) { github.markAllNotificationsRead(prepared) }
           }
 
           DashboardSection {
@@ -610,15 +614,23 @@ Panel {
     property bool actionEnabled: false
     property bool actionBusy: false
     property bool actionArmed: false
+    property int actionRevision: 0
+    property var actionPrepare: null
+    property string preparedAction: ""
     signal toggleExpanded()
-    signal actionTriggered()
+    signal actionTriggered(string prepared)
 
-    function disarmAction() { section.actionArmed = false; actionArmTimer.stop() }
+    function disarmAction() {
+      section.actionArmed = false
+      section.preparedAction = ""
+      actionArmTimer.stop()
+    }
 
     // An armed confirmation must not outlive the button being clickable, or it
     // would fire on the first click once the button comes back.
     onActionBusyChanged: if (section.actionBusy) section.disarmAction()
     onActionEnabledChanged: if (!section.actionEnabled) section.disarmAction()
+    onActionRevisionChanged: if (section.actionArmed) section.disarmAction()
 
     width: parent ? parent.width : 0
     spacing: Style.space(8)
@@ -688,9 +700,17 @@ Panel {
         verticalPadding: Style.spacing.controlPaddingY
         onClicked: {
           if (section.actionBusy) return
-          if (!section.actionArmed) { section.actionArmed = true; actionArmTimer.restart(); return }
+          if (!section.actionArmed) {
+            var prepared = section.actionPrepare ? String(section.actionPrepare() || "") : "confirmed"
+            if (prepared === "") return
+            section.preparedAction = prepared
+            section.actionArmed = true
+            actionArmTimer.restart()
+            return
+          }
+          var confirmed = section.preparedAction
           section.disarmAction()
-          section.actionTriggered()
+          section.actionTriggered(confirmed)
         }
       }
       Button {
@@ -777,7 +797,7 @@ Panel {
       }
       PanelActionButton {
         visible: linkRow.showReadAction
-        enabled: !github.marking
+        enabled: !github.loading && !github.marking
         iconText: github.markingNotificationId === linkRow.notificationId ? "󰑐" : "󰄬"
         tooltipText: "Mark this notification read (M)"
         foreground: root.foreground

--- a/Panel.qml
+++ b/Panel.qml
@@ -153,12 +153,17 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  onOpenedChanged: if (opened) {
-    cursorActive = false
-    cursorIndex = 0
-    if (panelFlick) panelFlick.contentY = 0
-    github.refresh()
-    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  onOpenedChanged: {
+    // A pending confirmation must never survive the panel closing, or the next
+    // open would run a destructive action on a single click.
+    if (notificationsSection) notificationsSection.disarmAction()
+    if (opened) {
+      cursorActive = false
+      cursorIndex = 0
+      if (panelFlick) panelFlick.contentY = 0
+      github.refresh()
+      Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+    }
   }
   onCursorTargetsChanged: ensureCursor()
 
@@ -293,6 +298,7 @@ Panel {
           }
 
           DashboardSection {
+            id: notificationsSection
             title: "UNREAD NOTIFICATIONS"
             count: github.notifications.length
             emptyText: github.state === "ready" ? "You're all caught up." : "No notifications loaded."
@@ -301,6 +307,11 @@ Panel {
             openUrl: "https://github.com/notifications"
             onToggleExpanded: root.notificationsExpanded = !root.notificationsExpanded
             delegateComponent: notificationDelegate
+            actionText: "Mark all read"
+            actionBusyText: "Marking…"
+            actionEnabled: github.state === "ready"
+            actionBusy: github.markingAllNotifications
+            onActionTriggered: github.markAllNotificationsRead()
           }
 
           DashboardSection {
@@ -590,7 +601,19 @@ Panel {
     property Component delegateComponent: null
     property bool expanded: false
     property string openUrl: ""
+    // Optional destructive action. It arms on the first click and only runs on
+    // the second, so a stray click cannot clear the section.
+    property string actionText: ""
+    property string actionConfirmText: "Confirm?"
+    property string actionBusyText: ""
+    property bool actionEnabled: false
+    property bool actionBusy: false
+    property bool actionArmed: false
     signal toggleExpanded()
+    signal actionTriggered()
+
+    function disarmAction() { section.actionArmed = false; actionArmTimer.stop() }
+
     width: parent ? parent.width : 0
     spacing: Style.space(8)
 
@@ -615,11 +638,24 @@ Panel {
       spacing: Style.space(4)
       Repeater { model: section.model; delegate: section.delegateComponent }
     }
+    Timer {
+      id: actionArmTimer
+      interval: 4000
+      repeat: false
+      onTriggered: section.actionArmed = false
+    }
     Row {
-      visible: section.count > root.activityPreviewCount
+      id: sectionFooter
+      // Expanding is only offered once the section is truncated; below that
+      // threshold the remaining controls render unbordered on their own line.
+      readonly property bool expandable: section.count > root.activityPreviewCount
+      readonly property bool showOpen: section.count > 0 && section.openUrl !== ""
+      readonly property bool showAction: section.count > 0 && section.actionEnabled && section.actionText !== ""
+      visible: expandable || showOpen || showAction
       anchors.horizontalCenter: parent.horizontalCenter
       spacing: Style.space(12)
       Button {
+        visible: sectionFooter.expandable
         text: section.expanded ? "Show less" : (section.count > root.activityExpandedCount ? "Show 25" : "Show all " + section.count)
         bordered: true
         foreground: root.foreground
@@ -629,26 +665,31 @@ Panel {
         onClicked: section.toggleExpanded()
       }
       Button {
-        visible: section.openUrl !== ""
+        visible: sectionFooter.showAction
+        enabled: !section.actionBusy
+        text: section.actionBusy ? section.actionBusyText : (section.actionArmed ? section.actionConfirmText : section.actionText)
+        bordered: sectionFooter.expandable
+        foreground: section.actionArmed ? root.urgent : root.foreground
+        fontFamily: root.fontFamily
+        fontSize: Style.font.caption
+        verticalPadding: Style.spacing.controlPaddingY
+        onClicked: {
+          if (section.actionBusy) return
+          if (!section.actionArmed) { section.actionArmed = true; actionArmTimer.restart(); return }
+          section.disarmAction()
+          section.actionTriggered()
+        }
+      }
+      Button {
+        visible: sectionFooter.showOpen
         text: "Open in GitHub  󰅂"
-        bordered: true
+        bordered: sectionFooter.expandable
         foreground: root.foreground
         fontFamily: root.fontFamily
         fontSize: Style.font.caption
         verticalPadding: Style.spacing.controlPaddingY
         onClicked: root.openUrl(section.openUrl)
       }
-    }
-    Button {
-      visible: section.count > 0 && section.count <= root.activityPreviewCount && section.openUrl !== ""
-      anchors.horizontalCenter: parent.horizontalCenter
-      text: "Open in GitHub  󰅂"
-      bordered: false
-      foreground: root.foreground
-      fontFamily: root.fontFamily
-      fontSize: Style.font.caption
-      verticalPadding: Style.spacing.controlPaddingY
-      onClicked: root.openUrl(section.openUrl)
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Your GitHub work, directly in the Omarchy bar.
 
 The dashboard is ordered by urgency so the most actionable work appears first:
 
-- **Unread notifications** — open the related thread or mark it read in place
+- **Unread notifications** — open the related thread, mark it read in place, or clear the whole list
 - **Review requests** — see pull requests waiting on your review
 - **My pull requests** — track the pull requests you opened and the state of their checks
 - **Assigned issues** — keep track of open issues assigned to you
@@ -26,6 +26,7 @@ Repository search, metric filters, and sorting make even large GitHub accounts m
 - Compact previews that keep busy accounts readable
 - Direct links to notifications, pull requests, issues, workflow runs, and repositories
 - One-click notification mark-as-read, confirmed by GitHub before removal
+- Bulk mark-as-read behind a confirmation step, bounded to the threads on screen
 - Complete paginated repository and notification fetching
 - Configurable Actions scanning with bounded concurrency
 - Graceful partial results when an endpoint or repository is unavailable
@@ -101,6 +102,8 @@ omarchy plugin remove robzolkos.github
 | Right or middle click Octocat | Refresh |
 | Click a row | Open it on GitHub |
 | Check button on a notification | Mark the thread read after GitHub confirms it |
+| **Mark all read** in the notifications footer | Arm the bulk mark-as-read |
+| **Confirm?** on the armed button | Mark every notification on screen read |
 | `j` / `k` or arrow keys | Move through visible rows |
 | `Enter` / `Space` | Open the highlighted row |
 | `m` | Mark the highlighted notification read |
@@ -110,6 +113,8 @@ omarchy plugin remove robzolkos.github
 | `Escape` elsewhere | Close the panel |
 
 Activity sections show five items initially and expand to a bounded list of 25. **Open in GitHub** takes you to the corresponding complete GitHub view where one is available.
+
+The notifications footer also carries **Mark all read**. The first click arms it and the label becomes **Confirm?**; only the second click sends the request. The confirmation lapses after a few seconds, when the panel closes, and whenever another mark is already running. The request is bounded by the newest thread on screen, so anything GitHub received after the last refresh stays unread. Large inboxes are processed asynchronously by GitHub, so an immediate refresh can briefly show threads that are already on their way out.
 
 ## Repository dashboard
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ omarchy plugin remove robzolkos.github
 
 Activity sections show five items initially and expand to a bounded list of 25. **Open in GitHub** takes you to the corresponding complete GitHub view where one is available.
 
-The notifications footer also carries **Mark all read**. The first click arms it and the label becomes **Confirm?**; only the second click sends the request. The confirmation lapses after a few seconds, when the panel closes, and whenever another mark is already running. The request is bounded by the newest thread on screen, so anything GitHub received after the last refresh stays unread. Large inboxes are processed asynchronously by GitHub, so an immediate refresh can briefly show threads that are already on their way out.
+The notifications footer also carries **Mark all read**. The first click captures the displayed notification snapshot and changes the label to **Confirm?**; only the second click sends the request. The confirmation lapses after a few seconds, when the panel closes, when a refresh changes the notification list, and whenever another mark is running. Notifications before the newest displayed second are handled in bulk, while displayed threads from that boundary second are marked by ID so same-second arrivals stay unread. The dashboard refreshes from GitHub after every attempt; large inboxes processed asynchronously may briefly retain threads that are already on their way out.
 
 ## Repository dashboard
 
@@ -155,6 +155,7 @@ From an existing checkout, validate and test the plugin:
 omarchy plugin validate .
 tests/helper-test.sh
 tests/panel-source-test.sh
+tests/service-source-test.sh
 ```
 
 Install that checkout for local iteration:

--- a/Service.qml
+++ b/Service.qml
@@ -28,9 +28,11 @@ Item {
     property string _stderr: ""
     property bool refreshQueued: false
     property string markingNotificationId: ""
+    property bool markingAllNotifications: false
     property string notificationActionStatus: ""
     property string _markStdout: ""
     property string _markStderr: ""
+    property string _markBoundary: ""
     readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 900, 60, 3600)
     readonly property int unreadCount: notifications.length
     readonly property int actionCount: actions.length
@@ -145,6 +147,27 @@ Item {
         markProcess.running = true;
     }
 
+    // Bounded by the timestamp of the data on screen so threads that arrived
+    // since the last refresh are never cleared unseen.
+    function markAllNotificationsRead() {
+        if (notifications.length === 0 || markProcess.running)
+            return ;
+
+        var boundary = String(fetchedAt || "");
+        if (boundary === "") {
+            notificationActionStatus = "Refresh before marking everything read.";
+            actionStatusTimer.restart();
+            return ;
+        }
+        markingAllNotifications = true;
+        notificationActionStatus = "Marking all notifications read…";
+        _markStdout = "";
+        _markStderr = "";
+        _markBoundary = boundary;
+        markProcess.command = [helperPath(), "--mark-all-read-before", boundary];
+        markProcess.running = true;
+    }
+
     visible: false
 
     Timer {
@@ -211,16 +234,30 @@ Item {
                 response = JSON.parse(String(markOutput.text || root._markStdout || ""));
             } catch (error) {
             }
+            var all = root.markingAllNotifications;
             if (exitCode === 0 && response && response.state === "ready") {
-                var markedId = root.markingNotificationId;
-                root.notifications = root.notifications.filter(function(item) {
-                    return String(item.id || "") !== markedId;
-                });
-                root.notificationActionStatus = "Notification marked read.";
+                if (all) {
+                    // Drop only what the request covered; a refresh may have
+                    // landed newer threads while the helper was running.
+                    var boundary = root._markBoundary;
+                    root.notifications = root.notifications.filter(function(item) {
+                        return String(item.updatedAt || "") > boundary;
+                    });
+                    root.notificationActionStatus = "All notifications marked read.";
+                } else {
+                    var markedId = root.markingNotificationId;
+                    root.notifications = root.notifications.filter(function(item) {
+                        return String(item.id || "") !== markedId;
+                    });
+                    root.notificationActionStatus = "Notification marked read.";
+                }
             } else {
-                root.notificationActionStatus = response && response.message ? String(response.message) : String(markErrors.text || root._markStderr || "Could not mark notification read.").trim();
+                var fallback = all ? "Could not mark all notifications read." : "Could not mark notification read.";
+                root.notificationActionStatus = response && response.message ? String(response.message) : String(markErrors.text || root._markStderr || fallback).trim();
             }
             root.markingNotificationId = "";
+            root.markingAllNotifications = false;
+            root._markBoundary = "";
             actionStatusTimer.restart();
         }
 

--- a/Service.qml
+++ b/Service.qml
@@ -15,6 +15,7 @@ Item {
     property string login: ""
     property string fetchedAt: ""
     property var notifications: []
+    property int notificationsRevision: 0
     property var reviewRequests: []
     property var assignedIssues: []
     property var myPullRequests: []
@@ -32,7 +33,6 @@ Item {
     property string notificationActionStatus: ""
     property string _markStdout: ""
     property string _markStderr: ""
-    property string _markBoundary: ""
     // Single-thread and bulk marking share one process, so the panel gates every
     // entry point on this rather than on whichever flag a given call happens to
     // set. A caller added later inherits the guard instead of having to know.
@@ -103,10 +103,11 @@ Item {
     }
 
     function refresh() {
-        if (fetchProcess.running) {
+        if (fetchProcess.running || markProcess.running) {
             refreshQueued = true;
             return ;
         }
+        refreshQueued = false;
         loading = true;
         _stdout = "";
         _stderr = "";
@@ -122,6 +123,7 @@ Item {
             login = String(data.login || "");
             fetchedAt = String(data.fetchedAt || "");
             notifications = Array.isArray(data.notifications) ? data.notifications : [];
+            notificationsRevision++;
             reviewRequests = Array.isArray(data.reviewRequests) ? data.reviewRequests : [];
             assignedIssues = Array.isArray(data.assignedIssues) ? data.assignedIssues : [];
             myPullRequests = Array.isArray(data.myPullRequests) ? data.myPullRequests : [];
@@ -140,9 +142,10 @@ Item {
 
     function markNotificationRead(id) {
         var value = String(id || "");
-        if (value === "" || markProcess.running)
+        if (value === "" || loading || fetchProcess.running || markProcess.running)
             return ;
 
+        actionStatusTimer.stop();
         markingNotificationId = value;
         notificationActionStatus = "Marking notification read…";
         _markStdout = "";
@@ -151,32 +154,83 @@ Item {
         markProcess.running = true;
     }
 
-    // Bounded by the newest thread on screen so anything that arrived since the
-    // last refresh stays unread. The boundary is GitHub's own updated_at rather
-    // than fetchedAt, which comes from the local clock: a machine running fast
-    // would push the boundary into the future and clear threads never displayed.
-    function markAllNotificationsRead() {
-        if (notifications.length === 0 || markProcess.running)
-            return ;
+    function canonicalNotificationTimestamp(value) {
+        var text = String(value || "");
+        if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/.test(text))
+            return "";
+
+        var milliseconds = Date.parse(text);
+        if (!isFinite(milliseconds) || new Date(milliseconds).toISOString().replace(".000Z", "Z") !== text)
+            return "";
+
+        return milliseconds <= Date.now() ? text : "";
+    }
+
+    // Capture the exact displayed boundary on the first click. The panel binds
+    // confirmation to notificationsRevision, so any refresh invalidates this
+    // prepared value before the destructive second click can run.
+    function prepareMarkAllNotificationsRead() {
+        if (notifications.length === 0 || loading || fetchProcess.running || markProcess.running)
+            return "";
 
         var boundary = "";
         for (var i = 0; i < notifications.length; i++) {
-            var updated = String(notifications[i].updatedAt || "");
+            var updated = canonicalNotificationTimestamp(notifications[i].updatedAt);
+            if (updated === "") {
+                notificationActionStatus = "Refresh before marking everything read.";
+                actionStatusTimer.restart();
+                return "";
+            }
             if (updated > boundary)
                 boundary = updated;
-
         }
-        if (boundary === "") {
+
+        var boundaryIds = [];
+        for (var j = 0; j < notifications.length; j++) {
+            if (String(notifications[j].updatedAt || "") !== boundary)
+                continue;
+            var id = String(notifications[j].id || "");
+            if (!/^\d+$/.test(id)) {
+                notificationActionStatus = "Refresh before marking everything read.";
+                actionStatusTimer.restart();
+                return "";
+            }
+            boundaryIds.push(id);
+        }
+        return JSON.stringify({boundary: boundary, boundaryIds: boundaryIds, revision: notificationsRevision});
+    }
+
+    function markAllNotificationsRead(prepared) {
+        var confirmed = String(prepared || "");
+        if (confirmed === "" || loading || fetchProcess.running || markProcess.running)
+            return ;
+
+        // Recompute immediately before starting. This protects non-panel callers
+        // as well as the panel's revision-bound confirmation.
+        if (confirmed !== prepareMarkAllNotificationsRead()) {
+            notificationActionStatus = "Notifications changed. Confirm again.";
+            actionStatusTimer.restart();
+            return ;
+        }
+
+        var snapshot;
+        try {
+            snapshot = JSON.parse(confirmed);
+        } catch (error) {
             notificationActionStatus = "Refresh before marking everything read.";
             actionStatusTimer.restart();
             return ;
         }
+
+        actionStatusTimer.stop();
         markingAllNotifications = true;
         notificationActionStatus = "Marking all notifications read…";
         _markStdout = "";
         _markStderr = "";
-        _markBoundary = boundary;
-        markProcess.command = [helperPath(), "--mark-all-read-before", boundary];
+        var commandLine = [helperPath(), "--mark-all-read-before", String(snapshot.boundary || "")];
+        for (var i = 0; i < snapshot.boundaryIds.length; i++)
+            commandLine.push("--mark-boundary-notification", String(snapshot.boundaryIds[i]));
+        markProcess.command = commandLine;
         markProcess.running = true;
     }
 
@@ -248,29 +302,18 @@ Item {
             }
             var all = root.markingAllNotifications;
             if (exitCode === 0 && response && response.state === "ready") {
-                if (all) {
-                    // Drop only what the request covered; a refresh may have
-                    // landed newer threads while the helper was running.
-                    var boundary = root._markBoundary;
-                    root.notifications = root.notifications.filter(function(item) {
-                        return String(item.updatedAt || "") > boundary;
-                    });
-                    root.notificationActionStatus = "All notifications marked read.";
-                } else {
-                    var markedId = root.markingNotificationId;
-                    root.notifications = root.notifications.filter(function(item) {
-                        return String(item.id || "") !== markedId;
-                    });
-                    root.notificationActionStatus = "Notification marked read.";
-                }
+                root.notificationActionStatus = all ? "Notifications marked read. Refreshing…" : "Notification marked read. Refreshing…";
             } else {
                 var fallback = all ? "Could not mark all notifications read." : "Could not mark notification read.";
                 root.notificationActionStatus = response && response.message ? String(response.message) : String(markErrors.text || root._markStderr || fallback).trim();
             }
             root.markingNotificationId = "";
             root.markingAllNotifications = false;
-            root._markBoundary = "";
             actionStatusTimer.restart();
+            // GitHub is authoritative after every attempt. This reconciles
+            // successful, failed, and partially completed bulk operations.
+            root.refreshQueued = false;
+            Qt.callLater(root.refresh);
         }
 
         stdout: StdioCollector {

--- a/Service.qml
+++ b/Service.qml
@@ -33,6 +33,10 @@ Item {
     property string _markStdout: ""
     property string _markStderr: ""
     property string _markBoundary: ""
+    // Single-thread and bulk marking share one process, so the panel gates every
+    // entry point on this rather than on whichever flag a given call happens to
+    // set. A caller added later inherits the guard instead of having to know.
+    readonly property bool marking: markProcess.running
     readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 900, 60, 3600)
     readonly property int unreadCount: notifications.length
     readonly property int actionCount: actions.length
@@ -147,13 +151,21 @@ Item {
         markProcess.running = true;
     }
 
-    // Bounded by the timestamp of the data on screen so threads that arrived
-    // since the last refresh are never cleared unseen.
+    // Bounded by the newest thread on screen so anything that arrived since the
+    // last refresh stays unread. The boundary is GitHub's own updated_at rather
+    // than fetchedAt, which comes from the local clock: a machine running fast
+    // would push the boundary into the future and clear threads never displayed.
     function markAllNotificationsRead() {
         if (notifications.length === 0 || markProcess.running)
             return ;
 
-        var boundary = String(fetchedAt || "");
+        var boundary = "";
+        for (var i = 0; i < notifications.length; i++) {
+            var updated = String(notifications[i].updatedAt || "");
+            if (updated > boundary)
+                boundary = updated;
+
+        }
         if (boundary === "") {
             notificationActionStatus = "Refresh before marking everything read.";
             actionStatusTimer.restart();

--- a/omarchy-github-fetch
+++ b/omarchy-github-fetch
@@ -228,7 +228,7 @@ if [[ $action_scan != off && $(jq 'length' "$tmp/repos.json") -gt 0 ]]; then
     jq -s --arg repo "$repo" '[.[]|.workflow_runs[]?|select(.status=="completed")|{id,repository:$repo,name:(.name // .display_title // "Workflow"),title:(.display_title // ""),status:(.status // ""),conclusion:(.conclusion // ""),event:(.event // ""),branch:(.head_branch // ""),url:(.html_url // ""),createdAt:(.created_at // ""),updatedAt:(.updated_at // "")}]|unique_by(.id)' "$prefix.completed.pages" >"$prefix.completed.json" 2>/dev/null || printf '[]\n' >"$prefix.completed.json"
     if [[ $failed == true ]]; then api_error "actions $repo" "$prefix.err"; fi
   }
-  export tmp warnings cutoff_date; export -f scan_one api_error
+  export tmp warnings cutoff_date; export -f scan_one api_error error_detail
   xargs -r -P "$concurrency" -I{} bash -c 'scan_one "$1"' _ {} <"$tmp/scan-repos"
   jq -s 'add // []|unique_by(.id)|sort_by(.createdAt)|reverse' "$tmp"/action-*.active.json >"$tmp/actions.json" 2>/dev/null || printf '[]\n' >"$tmp/actions.json"
   jq -s --argjson cutoff "$cutoff_epoch" --argjson limit "$failed_limit" 'add // []|[.[]|select((.conclusion=="failure" or .conclusion=="timed_out" or .conclusion=="action_required" or .conclusion=="startup_failure") and ((.createdAt|fromdateiso8601) >= $cutoff))]|unique_by(.id)|sort_by(.updatedAt)|reverse|.[:$limit]' "$tmp"/action-*.completed.json >"$tmp/failed.json" 2>/dev/null || printf '[]\n' >"$tmp/failed.json"

--- a/omarchy-github-fetch
+++ b/omarchy-github-fetch
@@ -13,6 +13,7 @@ concurrency=6
 failed_days=7
 failed_limit=20
 mark_notification=""
+mark_all_before=""
 
 usage() {
   cat <<'EOF'
@@ -30,6 +31,9 @@ Usage: omarchy-github-fetch [options]
   --failed-days N               Show failed runs from the last N days, 1-30 (default: 7)
   --failed-limit N              Maximum recent failed runs, 1-100 (default: 20)
   --mark-notification-read ID   Mark one notification thread read and exit
+  --mark-all-read-before TIME   Mark every notification updated at or before
+                                TIME (ISO 8601 UTC, e.g. 2024-05-01T12:00:00Z)
+                                read and exit
 EOF
 }
 
@@ -48,6 +52,7 @@ while (($#)); do
     --failed-days) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; failed_days=$2; shift 2 ;;
     --failed-limit) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; failed_limit=$2; shift 2 ;;
     --mark-notification-read) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; mark_notification=$2; shift 2 ;;
+    --mark-all-read-before) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; mark_all_before=$2; shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -71,6 +76,8 @@ fi
 command -v gh >/dev/null 2>&1 || { emit_state gh-not-installed "GitHub CLI is not installed or not on PATH."; exit 0; }
 gh auth status -h github.com >/dev/null 2>&1 || { emit_state logged-out "Sign in with gh auth login to load GitHub data."; exit 0; }
 
+error_detail() { tr '\n' ' ' <"$1" | sed 's/[[:space:]]\+/ /g;s/^ //;s/ $//' | cut -c1-240; }
+
 if [[ -n $mark_notification ]]; then
   if error=$(mktemp); then
     if gh api --method PATCH "/notifications/threads/$mark_notification" >/dev/null 2>"$error"; then
@@ -78,9 +85,28 @@ if [[ -n $mark_notification ]]; then
       jq -n --arg id "$mark_notification" '{state:"ready",message:"Notification marked read.",notificationId:$id}'
       exit 0
     fi
-    detail=$(tr '\n' ' ' <"$error" | sed 's/[[:space:]]\+/ /g;s/^ //;s/ $//' | cut -c1-240)
+    detail=$(error_detail "$error")
     rm -f "$error"
     jq -n --arg id "$mark_notification" --arg message "${detail:-Could not mark notification read.}" '{state:"error",message:$message,notificationId:$id}'
+    exit 1
+  fi
+fi
+
+# Marking everything read is scoped to a timestamp so threads that arrived
+# after the dashboard was last refreshed stay unread. GitHub defaults
+# last_read_at to the current time, which would silently clear notifications
+# the user never saw.
+if [[ -n $mark_all_before ]]; then
+  [[ $mark_all_before =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || { jq -n --arg at "$mark_all_before" '{state:"error",message:"Invalid last-read timestamp.",lastReadAt:$at}'; exit 2; }
+  if error=$(mktemp); then
+    if gh api --method PUT /notifications -f last_read_at="$mark_all_before" >/dev/null 2>"$error"; then
+      rm -f "$error"
+      jq -n --arg at "$mark_all_before" '{state:"ready",message:"All notifications marked read.",lastReadAt:$at}'
+      exit 0
+    fi
+    detail=$(error_detail "$error")
+    rm -f "$error"
+    jq -n --arg at "$mark_all_before" --arg message "${detail:-Could not mark all notifications read.}" '{state:"error",message:$message,lastReadAt:$at}'
     exit 1
   fi
 fi
@@ -91,7 +117,7 @@ warnings="$tmp/warnings"
 : >"$warnings"
 api_error() {
   local label=$1 err=$2 detail
-  detail=$(tr '\n' ' ' <"$err" | sed 's/[[:space:]]\+/ /g;s/^ //;s/ $//' | cut -c1-240)
+  detail=$(error_detail "$err")
   [[ -n $detail ]] || detail="request failed"
   printf '%s: %s\n' "$label" "$detail" >>"$warnings"
 }

--- a/omarchy-github-fetch
+++ b/omarchy-github-fetch
@@ -14,6 +14,7 @@ failed_days=7
 failed_limit=20
 mark_notification=""
 mark_all_before=""
+mark_boundary_notifications=()
 
 usage() {
   cat <<'EOF'
@@ -31,9 +32,10 @@ Usage: omarchy-github-fetch [options]
   --failed-days N               Show failed runs from the last N days, 1-30 (default: 7)
   --failed-limit N              Maximum recent failed runs, 1-100 (default: 20)
   --mark-notification-read ID   Mark one notification thread read and exit
-  --mark-all-read-before TIME   Mark every notification updated at or before
-                                TIME (ISO 8601 UTC, e.g. 2024-05-01T12:00:00Z)
-                                read and exit
+  --mark-all-read-before TIME   Mark fetched notifications through TIME read
+  --mark-boundary-notification ID
+                                Preserve same-second arrivals by marking only
+                                the fetched boundary thread ID (repeatable)
 EOF
 }
 
@@ -53,6 +55,7 @@ while (($#)); do
     --failed-limit) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; failed_limit=$2; shift 2 ;;
     --mark-notification-read) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; mark_notification=$2; shift 2 ;;
     --mark-all-read-before) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; mark_all_before=$2; shift 2 ;;
+    --mark-boundary-notification) [[ $# -ge 2 ]] || { echo "missing value for $1" >&2; exit 2; }; mark_boundary_notifications+=("$2"); shift 2 ;;
     -h|--help) usage; exit 0 ;;
     *) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
   esac
@@ -73,45 +76,82 @@ if [[ -n $mark_notification && ! $mark_notification =~ ^[0-9]+$ ]]; then
   jq -n --arg id "$mark_notification" '{state:"error",message:"Invalid notification thread id.",notificationId:$id}'
   exit 2
 fi
+mark_bulk_before=""
+if [[ -n $mark_all_before ]]; then
+  if [[ ! $mark_all_before =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] ||
+     ! jq -en --arg at "$mark_all_before" '($at | fromdateiso8601) as $time | (($time | todateiso8601) == $at and $time <= now)' >/dev/null 2>&1; then
+    jq -n --arg at "$mark_all_before" '{state:"error",message:"Invalid or future last-read timestamp.",lastReadAt:$at}'
+    exit 2
+  fi
+  ((${#mark_boundary_notifications[@]} > 0)) || { jq -n --arg at "$mark_all_before" '{state:"error",message:"At least one boundary notification is required.",lastReadAt:$at}'; exit 2; }
+  for id in "${mark_boundary_notifications[@]}"; do
+    [[ $id =~ ^[0-9]+$ ]] || { jq -n --arg id "$id" '{state:"error",message:"Invalid boundary notification thread id.",notificationId:$id}'; exit 2; }
+  done
+  mark_bulk_before=$(jq -nr --arg at "$mark_all_before" '($at | fromdateiso8601) - 1 | todateiso8601')
+elif ((${#mark_boundary_notifications[@]} > 0)); then
+  jq -n '{state:"error",message:"Boundary notifications require --mark-all-read-before."}'
+  exit 2
+fi
+if [[ -n $mark_notification && -n $mark_all_before ]]; then
+  jq -n '{state:"error",message:"Choose one notification marking operation."}'
+  exit 2
+fi
 command -v gh >/dev/null 2>&1 || { emit_state gh-not-installed "GitHub CLI is not installed or not on PATH."; exit 0; }
 gh auth status -h github.com >/dev/null 2>&1 || { emit_state logged-out "Sign in with gh auth login to load GitHub data."; exit 0; }
 
-error_detail() { tr '\n' ' ' <"$1" | sed 's/[[:space:]]\+/ /g;s/^ //;s/ $//' | cut -c1-240; }
+error_detail() {
+  tr '\n' ' ' <"$1" |
+    sed -E 's/(gh[pousr]_[A-Za-z0-9_]{20,}|github_pat_[A-Za-z0-9_]{20,})/[REDACTED]/g; s/(Authorization: *(token|Bearer) +)[^ ]+/\1[REDACTED]/Ig; s/[[:space:]]+/ /g; s/^ //; s/ $//' |
+    cut -c1-240
+}
 
 if [[ -n $mark_notification ]]; then
-  if error=$(mktemp); then
-    if gh api --method PATCH "/notifications/threads/$mark_notification" >/dev/null 2>"$error"; then
-      rm -f "$error"
-      jq -n --arg id "$mark_notification" '{state:"ready",message:"Notification marked read.",notificationId:$id}'
-      exit 0
-    fi
-    detail=$(error_detail "$error")
-    rm -f "$error"
-    jq -n --arg id "$mark_notification" --arg message "${detail:-Could not mark notification read.}" '{state:"error",message:$message,notificationId:$id}'
+  if ! error=$(mktemp); then
+    jq -n --arg id "$mark_notification" '{state:"error",message:"Could not prepare the notification request.",notificationId:$id}'
     exit 1
   fi
+  if gh api --method PATCH "/notifications/threads/$mark_notification" >/dev/null 2>"$error"; then
+    rm -f "$error"
+    jq -n --arg id "$mark_notification" '{state:"ready",message:"Notification marked read.",notificationId:$id}'
+    exit 0
+  fi
+  detail=$(error_detail "$error")
+  rm -f "$error"
+  jq -n --arg id "$mark_notification" --arg message "${detail:-Could not mark notification read.}" '{state:"error",message:$message,notificationId:$id}'
+  exit 1
 fi
 
-# Marking everything read is scoped to a timestamp so threads that arrived
-# after the dashboard was last refreshed stay unread. GitHub defaults
-# last_read_at to the current time, which would silently clear notifications
-# the user never saw.
+# Mark everything before the boundary second in bulk, then mark only the
+# fetched threads from the boundary second. A new thread arriving in that same
+# second remains unread because its ID is not in the confirmed snapshot.
 if [[ -n $mark_all_before ]]; then
-  [[ $mark_all_before =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || { jq -n --arg at "$mark_all_before" '{state:"error",message:"Invalid last-read timestamp.",lastReadAt:$at}'; exit 2; }
-  if error=$(mktemp); then
-    if gh api --method PUT /notifications -f last_read_at="$mark_all_before" >/dev/null 2>"$error"; then
-      rm -f "$error"
-      jq -n --arg at "$mark_all_before" '{state:"ready",message:"All notifications marked read.",lastReadAt:$at}'
-      exit 0
-    fi
+  if ! error=$(mktemp); then
+    jq -n --arg at "$mark_all_before" '{state:"error",message:"Could not prepare the bulk notification request.",lastReadAt:$at}'
+    exit 1
+  fi
+  if ! gh api --method PUT /notifications -f last_read_at="$mark_bulk_before" >/dev/null 2>"$error"; then
     detail=$(error_detail "$error")
     rm -f "$error"
     jq -n --arg at "$mark_all_before" --arg message "${detail:-Could not mark all notifications read.}" '{state:"error",message:$message,lastReadAt:$at}'
     exit 1
   fi
+  for id in "${mark_boundary_notifications[@]}"; do
+    if ! gh api --method PATCH "/notifications/threads/$id" >/dev/null 2>"$error"; then
+      detail=$(error_detail "$error")
+      rm -f "$error"
+      jq -n --arg at "$mark_all_before" --arg id "$id" --arg message "${detail:-Could not mark a boundary notification read.}" '{state:"error",message:$message,lastReadAt:$at,notificationId:$id}'
+      exit 1
+    fi
+  done
+  rm -f "$error"
+  jq -n --arg at "$mark_all_before" '{state:"ready",message:"All displayed notifications marked read.",lastReadAt:$at}'
+  exit 0
 fi
 
-tmp=$(mktemp -d)
+if ! tmp=$(mktemp -d); then
+  emit_state error "Could not prepare temporary storage for the GitHub refresh."
+  exit 1
+fi
 trap 'rm -rf "$tmp"' EXIT
 warnings="$tmp/warnings"
 : >"$warnings"

--- a/tests/helper-test.sh
+++ b/tests/helper-test.sh
@@ -144,4 +144,27 @@ assert_jq '.state == "ready" and .lastReadAt == "2026-01-03T00:00:00Z"' "$mark_a
 mark_all_failed=$(PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2020-01-01T00:00:00Z) || true
 assert_jq '.state == "error" and .lastReadAt == "2020-01-01T00:00:00Z"' "$mark_all_failed" "failed mark all reports an error"
 
+# The Actions scan runs in xargs subshells, which only see exported functions.
+# An unexported helper there degrades every warning to the generic fallback
+# instead of the API's own explanation.
+cat >"$sandbox/gh" <<'GH'
+#!/usr/bin/env bash
+if [[ $1 == auth ]]; then exit 0; fi
+if [[ $1 == api && $2 == graphql ]]; then
+  cat <<'JSON'
+{"data":{"viewer":{"login":"octocat","repositories":{"nodes":[{"name":"hello","nameWithOwner":"octocat/hello","url":"https://github.com/octocat/hello","isArchived":false,"isFork":false,"stargazerCount":1,"updatedAt":"2026-01-01T00:00:00Z","issues":{"totalCount":0},"pullRequests":{"totalCount":0}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}},"rateLimit":{"remaining":10,"resetAt":"2026-01-01T01:00:00Z","cost":1}}}
+JSON
+  exit 0
+fi
+endpoint=${*: -1}
+if [[ $endpoint == /repos/octocat/hello/actions/runs* ]]; then
+  echo "HTTP 403: Resource not accessible by integration" >&2
+  exit 1
+fi
+printf '%s\n' '[]'
+GH
+chmod +x "$sandbox/gh"
+scoped=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan all)
+assert_jq '(.warnings|length) > 0 and (.warnings[0]|test("403"))' "$scoped" "Actions warnings keep the API error text"
+
 echo "helper tests passed"

--- a/tests/helper-test.sh
+++ b/tests/helper-test.sh
@@ -13,6 +13,12 @@ if "$HELPER" --failed-days 0 >/dev/null 2>&1; then fail "invalid failed window s
 if "$HELPER" --mark-notification-read nope >/dev/null 2>&1; then fail "invalid notification id succeeded"; fi
 if "$HELPER" --mark-all-read-before nope >/dev/null 2>&1; then fail "invalid last-read timestamp succeeded"; fi
 if "$HELPER" --mark-all-read-before 2026-01-03 >/dev/null 2>&1; then fail "date without time succeeded"; fi
+if "$HELPER" --mark-all-read-before 2026-02-30T00:00:00Z --mark-boundary-notification 123 >/dev/null 2>&1; then fail "invalid calendar timestamp succeeded"; fi
+if "$HELPER" --mark-all-read-before 9999-01-01T00:00:00Z --mark-boundary-notification 123 >/dev/null 2>&1; then fail "future timestamp succeeded"; fi
+near_future=$(jq -nr 'now + 60 | todateiso8601')
+if "$HELPER" --mark-all-read-before "$near_future" --mark-boundary-notification 123 >/dev/null 2>&1; then fail "near-future timestamp succeeded"; fi
+if "$HELPER" --mark-all-read-before 2020-01-03T00:00:00Z >/dev/null 2>&1; then fail "bulk mark without a boundary notification succeeded"; fi
+if "$HELPER" --mark-all-read-before 2020-01-03T00:00:00Z --mark-boundary-notification nope >/dev/null 2>&1; then fail "invalid boundary notification id succeeded"; fi
 
 sandbox=$(mktemp -d)
 trap 'rm -rf "$sandbox"' EXIT
@@ -36,12 +42,16 @@ cat >"$sandbox/gh" <<'GH'
 #!/usr/bin/env bash
 if [[ $1 == auth ]]; then exit 0; fi
 if [[ $1 == api && $2 == --method && $3 == PATCH ]]; then
-  [[ $4 == /notifications/threads/123 ]] || exit 9
+  printf '%s\n' "$*" >>"$GH_TEST_LOG"
+  id=${4##*/}
+  [[ $id == 123 || $id == 124 || $id == 125 ]] || exit 9
+  if [[ ${GH_FAIL_PATCH_ID:-} == "$id" ]]; then echo "boundary patch rejected ghp_abcdefghijklmnopqrstuvwxyz123456" >&2; exit 8; fi
   printf '%s\n' '{}'; exit 0
 fi
 if [[ $1 == api && $2 == --method && $3 == PUT ]]; then
+  printf '%s\n' "$*" >>"$GH_TEST_LOG"
   [[ $4 == /notifications ]] || exit 9
-  [[ $5 == -f && $6 == last_read_at=2026-01-03T00:00:00Z ]] || { echo "unexpected last_read_at: ${6-}" >&2; exit 9; }
+  [[ $5 == -f && $6 == last_read_at=2020-01-02T23:59:59Z ]] || { echo "unexpected last_read_at: ${6-}" >&2; exit 9; }
   printf '%s\n' '{}'; exit 0
 fi
 if [[ $1 == api && $2 == graphql ]]; then
@@ -135,14 +145,52 @@ out_archived=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan off --include-archi
 assert_jq '.myPullRequests|length == 2' "$out_archived" "authored pull requests survive the archived setting"
 grep -q 'author:@me' "$GH_TEST_LOG" || fail "authored pull request search did not run"
 if grep -q 'archived:false' "$GH_TEST_LOG"; then fail "archived filter applied despite --include-archived true"; fi
+: >"$GH_TEST_LOG"
 mark=$(PATH="$sandbox:$PATH" "$HELPER" --mark-notification-read 123)
 assert_jq '.state == "ready" and .notificationId == "123"' "$mark" "mark notification read"
-mark_all=$(PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2026-01-03T00:00:00Z)
-assert_jq '.state == "ready" and .lastReadAt == "2026-01-03T00:00:00Z"' "$mark_all" "mark all notifications read"
+: >"$GH_TEST_LOG"
+mark_all=$(PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2020-01-03T00:00:00Z --mark-boundary-notification 123 --mark-boundary-notification 124)
+assert_jq '.state == "ready" and .lastReadAt == "2020-01-03T00:00:00Z"' "$mark_all" "mark all notifications read"
+mapfile -t mark_calls <"$GH_TEST_LOG"
+[[ ${#mark_calls[@]} -eq 3 ]] || fail "bulk mark made an unexpected number of API calls"
+[[ ${mark_calls[0]} == 'api --method PUT /notifications -f last_read_at=2020-01-02T23:59:59Z' ]] || fail "bulk mark did not stop before the boundary second"
+[[ ${mark_calls[1]} == 'api --method PATCH /notifications/threads/123' && ${mark_calls[2]} == 'api --method PATCH /notifications/threads/124' ]] || fail "bulk mark did not patch exactly the confirmed boundary notifications"
+: >"$GH_TEST_LOG"
+set +e
+mark_partial=$(GH_FAIL_PATCH_ID=124 PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2020-01-03T00:00:00Z --mark-boundary-notification 123 --mark-boundary-notification 124 --mark-boundary-notification 125)
+mark_partial_status=$?
+set -e
+[[ $mark_partial_status -eq 1 ]] || fail "partial boundary failure returned status $mark_partial_status"
+assert_jq '.state == "error" and .notificationId == "124" and (.message|test("boundary patch rejected")) and (.message|contains("ghp_")|not) and (.message|contains("[REDACTED]"))' "$mark_partial" "partial boundary failure reports the failing notification without exposing credentials"
+mapfile -t partial_calls <"$GH_TEST_LOG"
+[[ ${#partial_calls[@]} -eq 3 && ${partial_calls[0]} == 'api --method PUT /notifications -f last_read_at=2020-01-02T23:59:59Z' && ${partial_calls[1]} == 'api --method PATCH /notifications/threads/123' && ${partial_calls[2]} == 'api --method PATCH /notifications/threads/124' ]] || fail "partial boundary failure did not stop at the failing notification"
 # A rejected request must surface as an error payload rather than an empty
 # response, which is what a missing notifications scope looks like in practice.
-mark_all_failed=$(PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2020-01-01T00:00:00Z) || true
+set +e
+mark_all_failed=$(PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2020-01-01T00:00:00Z --mark-boundary-notification 123)
+mark_all_failed_status=$?
+set -e
+[[ $mark_all_failed_status -eq 1 ]] || fail "failed bulk mark returned status $mark_all_failed_status"
 assert_jq '.state == "error" and .lastReadAt == "2020-01-01T00:00:00Z"' "$mark_all_failed" "failed mark all reports an error"
+
+mkdir "$sandbox/failbin"
+cat >"$sandbox/failbin/mktemp" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "$sandbox/failbin/mktemp"
+set +e
+mark_setup_failed=$(PATH="$sandbox/failbin:$sandbox:$PATH" "$HELPER" --mark-notification-read 123)
+mark_setup_status=$?
+bulk_setup_failed=$(PATH="$sandbox/failbin:$sandbox:$PATH" "$HELPER" --mark-all-read-before 2020-01-03T00:00:00Z --mark-boundary-notification 123)
+bulk_setup_status=$?
+fetch_setup_failed=$(PATH="$sandbox/failbin:$sandbox:$PATH" "$HELPER")
+fetch_setup_status=$?
+set -e
+[[ $mark_setup_status -eq 1 && $bulk_setup_status -eq 1 && $fetch_setup_status -eq 1 ]] || fail "temporary-storage failures returned an unexpected status"
+assert_jq '.state == "error" and .notificationId == "123"' "$mark_setup_failed" "single mark setup failure reports an error"
+assert_jq '.state == "error" and .lastReadAt == "2020-01-03T00:00:00Z"' "$bulk_setup_failed" "bulk mark setup failure reports an error"
+assert_jq '.state == "error"' "$fetch_setup_failed" "refresh setup failure reports an error"
 
 # The Actions scan runs in xargs subshells, which only see exported functions.
 # An unexported helper there degrades every warning to the generic fallback

--- a/tests/helper-test.sh
+++ b/tests/helper-test.sh
@@ -11,6 +11,8 @@ bash -n "$HELPER"
 if "$HELPER" --action-scan invalid >/dev/null 2>&1; then fail "invalid scan mode succeeded"; fi
 if "$HELPER" --failed-days 0 >/dev/null 2>&1; then fail "invalid failed window succeeded"; fi
 if "$HELPER" --mark-notification-read nope >/dev/null 2>&1; then fail "invalid notification id succeeded"; fi
+if "$HELPER" --mark-all-read-before nope >/dev/null 2>&1; then fail "invalid last-read timestamp succeeded"; fi
+if "$HELPER" --mark-all-read-before 2026-01-03 >/dev/null 2>&1; then fail "date without time succeeded"; fi
 
 sandbox=$(mktemp -d)
 trap 'rm -rf "$sandbox"' EXIT
@@ -35,6 +37,11 @@ cat >"$sandbox/gh" <<'GH'
 if [[ $1 == auth ]]; then exit 0; fi
 if [[ $1 == api && $2 == --method && $3 == PATCH ]]; then
   [[ $4 == /notifications/threads/123 ]] || exit 9
+  printf '%s\n' '{}'; exit 0
+fi
+if [[ $1 == api && $2 == --method && $3 == PUT ]]; then
+  [[ $4 == /notifications ]] || exit 9
+  [[ $5 == -f && $6 == last_read_at=2026-01-03T00:00:00Z ]] || { echo "unexpected last_read_at: ${6-}" >&2; exit 9; }
   printf '%s\n' '{}'; exit 0
 fi
 if [[ $1 == api && $2 == graphql ]]; then
@@ -130,5 +137,11 @@ grep -q 'author:@me' "$GH_TEST_LOG" || fail "authored pull request search did no
 if grep -q 'archived:false' "$GH_TEST_LOG"; then fail "archived filter applied despite --include-archived true"; fi
 mark=$(PATH="$sandbox:$PATH" "$HELPER" --mark-notification-read 123)
 assert_jq '.state == "ready" and .notificationId == "123"' "$mark" "mark notification read"
+mark_all=$(PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2026-01-03T00:00:00Z)
+assert_jq '.state == "ready" and .lastReadAt == "2026-01-03T00:00:00Z"' "$mark_all" "mark all notifications read"
+# A rejected request must surface as an error payload rather than an empty
+# response, which is what a missing notifications scope looks like in practice.
+mark_all_failed=$(PATH="$sandbox:$PATH" "$HELPER" --mark-all-read-before 2020-01-01T00:00:00Z) || true
+assert_jq '.state == "error" and .lastReadAt == "2020-01-01T00:00:00Z"' "$mark_all_failed" "failed mark all reports an error"
 
 echo "helper tests passed"

--- a/tests/panel-source-test.sh
+++ b/tests/panel-source-test.sh
@@ -2,8 +2,7 @@
 set -euo pipefail
 
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
-PANEL="$ROOT/Panel.qml"
-PANEL_SOURCE=$(<"$PANEL")
+PANEL_SOURCE=$(<"$ROOT/Panel.qml")
 
 fail() { echo "FAIL: $*" >&2; exit 1; }
 assert_contains() {
@@ -16,5 +15,19 @@ assert_contains $'text: linkRow.title\n          textFormat: Text.PlainText' \
   "row titles are not forced to plain text"
 assert_contains $'text: linkRow.detail\n          textFormat: Text.PlainText' \
   "row details are not forced to plain text"
+assert_contains $'text: github.notificationActionStatus\n            textFormat: Text.PlainText' \
+  "notification action status is not forced to plain text"
+assert_contains $'return summary\n              }\n              textFormat: Text.PlainText' \
+  "dashboard warning text is not forced to plain text"
+assert_contains $'actionText: "Mark all read"\n            actionBusyText: "Marking…"\n            actionEnabled: github.state === "ready" && !github.loading\n            actionBusy: github.marking\n            actionRevision: github.notificationsRevision\n            actionPrepare: function() { return github.prepareMarkAllNotificationsRead() }\n            onActionTriggered: function(prepared) { github.markAllNotificationsRead(prepared) }' \
+  "notification bulk action is not bound to the prepared displayed snapshot"
+assert_contains $'onActionBusyChanged: if (section.actionBusy) section.disarmAction()\n    onActionEnabledChanged: if (!section.actionEnabled) section.disarmAction()\n    onActionRevisionChanged: if (section.actionArmed) section.disarmAction()' \
+  "bulk confirmation is not invalidated when notification state changes"
+assert_contains $'var confirmed = section.preparedAction\n          section.disarmAction()\n          section.actionTriggered(confirmed)' \
+  "bulk action does not submit the originally prepared snapshot"
+assert_contains $'function markSelectedRead() {\n    if (github.loading || github.marking) return' \
+  "keyboard notification marking is enabled during refresh"
+assert_contains $'PanelActionButton {\n        visible: linkRow.showReadAction\n        enabled: !github.loading && !github.marking' \
+  "notification row marking is enabled during refresh"
 
 echo "panel source tests passed"

--- a/tests/service-source-test.sh
+++ b/tests/service-source-test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SERVICE_SOURCE=$(<"$ROOT/Service.qml")
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_contains() {
+  [[ $SERVICE_SOURCE == *"$1"* ]] || fail "$2"
+}
+assert_not_contains() {
+  [[ $SERVICE_SOURCE != *"$1"* ]] || fail "$2"
+}
+
+assert_contains $'function refresh() {\n        if (fetchProcess.running || markProcess.running) {\n            refreshQueued = true;\n            return ;\n        }' \
+  "refresh and notification marking are not serialized"
+assert_contains $'notifications = Array.isArray(data.notifications) ? data.notifications : [];\n            notificationsRevision++;' \
+  "notification refreshes do not invalidate prepared confirmations"
+assert_contains $'function markNotificationRead(id) {\n        var value = String(id || "");\n        if (value === "" || loading || fetchProcess.running || markProcess.running)' \
+  "single-notification marking is not blocked during refresh"
+assert_contains $'function canonicalNotificationTimestamp(value) {\n        var text = String(value || "");\n        if (!/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$/.test(text))\n            return "";' \
+  "notification boundaries are not shape validated"
+assert_contains 'return milliseconds <= Date.now() ? text : "";' \
+  "future notification boundaries are accepted"
+assert_contains $'function prepareMarkAllNotificationsRead() {\n        if (notifications.length === 0 || loading || fetchProcess.running || markProcess.running)\n            return "";' \
+  "bulk confirmation can be prepared during refresh or marking"
+assert_contains $'if (!/^\\d+$/.test(id)) {\n                notificationActionStatus = "Refresh before marking everything read.";' \
+  "bulk confirmation accepts invalid boundary notification IDs"
+assert_contains 'return JSON.stringify({boundary: boundary, boundaryIds: boundaryIds, revision: notificationsRevision});' \
+  "bulk confirmation does not capture its boundary IDs and revision"
+assert_contains $'function markAllNotificationsRead(prepared) {\n        var confirmed = String(prepared || "");\n        if (confirmed === "" || loading || fetchProcess.running || markProcess.running)\n            return ;' \
+  "bulk marking is not blocked during refresh"
+assert_contains $'if (confirmed !== prepareMarkAllNotificationsRead()) {\n            notificationActionStatus = "Notifications changed. Confirm again.";' \
+  "bulk marking does not verify the confirmed snapshot"
+assert_contains $'var commandLine = [helperPath(), "--mark-all-read-before", String(snapshot.boundary || "")];\n        for (var i = 0; i < snapshot.boundaryIds.length; i++)\n            commandLine.push("--mark-boundary-notification", String(snapshot.boundaryIds[i]));' \
+  "bulk marking does not protect same-second arrivals"
+assert_contains $'// GitHub is authoritative after every attempt. This reconciles\n            // successful, failed, and partially completed bulk operations.\n            root.refreshQueued = false;\n            Qt.callLater(root.refresh);' \
+  "notification marking does not reconcile every result with an authoritative refresh"
+assert_not_contains 'root.notifications = root.notifications.filter' \
+  "notification marking still hides rows using stale local data"
+
+echo "service source tests passed"


### PR DESCRIPTION
Clearing a busy inbox one thread at a time is impractical, so this adds a **Mark all read** control to the notifications section footer.

## Behaviour

The button arms on the first click, its label becomes **Confirm?**, and only the second click sends the request. The confirmation lapses after a few seconds, when the panel closes, and whenever another mark is already running, so a stray click cannot empty the section.

## The timestamp boundary

`PUT /notifications` defaults `last_read_at` to the current time, which would clear threads that arrived after the dashboard last refreshed and were never displayed. The helper therefore sends an explicit boundary: the `updated_at` of the newest thread on screen.

That value is GitHub's own rather than the local clock. Using the fetch timestamp instead would reintroduce the same problem on any machine whose clock runs fast, for instance after a suspend/resume before NTP re-syncs.

## Shared process

Marking one thread and marking all of them drive the same `Process`. The service now exposes a single `marking` flag and the panel gates every entry point on it (per-row button, `m` key, the bulk button), so no path can land on a busy-process early return and silently do nothing.

## Notes

- `error_detail` is exported alongside `api_error`. The Actions scan runs in `xargs` subshells that only see exported functions, so without it every Actions warning collapsed to `request failed` instead of carrying the API's own message. A test covers it.
- No key binding for the bulk action. `m` already means "mark the highlighted notification read", and `onTextKey` does not receive modifiers, so `M` cannot be distinguished without changing what it does today. The button reaches the Tab chain the same way the other footer buttons do.
- GitHub processes large inboxes asynchronously and can return `202 Accepted`, so an immediate refresh may briefly show threads that are on their way out. The README says so rather than claiming GitHub confirms the bulk removal.

## Testing

`bash tests/helper-test.sh` passes. New cases cover the timestamp validation, a successful `PUT`, a rejected one (what a missing `notifications` scope looks like), and the Actions warning regression.

Also exercised against a live account with 87 unread notifications: armed, confirmed, cleared, and the section reported the result correctly.
