### PR TITLE
Add a section for pull requests you authored, with check state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run helper tests
         run: tests/helper-test.sh
+
+      - name: Run panel source tests
+        run: tests/panel-source-test.sh

--- a/Panel.qml
+++ b/Panel.qml
@@ -103,9 +103,9 @@ Panel {
 
   function checkLabel(checks) {
     if (checks === "SUCCESS") return "checks passing"
-    if (checks === "FAILURE") return "checks failing"
     if (checks === "ERROR") return "checks errored"
-    if (checks === "PENDING" || checks === "EXPECTED") return "checks running"
+    if (github.isBrokenCheck(checks)) return "checks failing"
+    if (github.isRunningCheck(checks)) return "checks running"
     return "no checks"
   }
 
@@ -235,8 +235,11 @@ Panel {
           PanelHero {
             width: parent.width
             title: github.login !== "" ? "GitHub · " + github.login : "GitHub"
+            // Mirrors every term of the alarming state, so the summary always
+            // explains why the bar icon is lit.
             meta: github.loading ? "Refreshing dashboard…" : (github.state === "ready" ?
-              github.unreadCount + " unread · " + github.reviewRequests.length + " reviews · " + github.actionCount + " active actions" : github.message)
+              github.unreadCount + " unread · " + github.reviewRequests.length + " reviews · " + github.actionCount + " active actions"
+                + (github.failingPullRequestCount > 0 ? " · " + github.failingPullRequestCount + " failing" : "") : github.message)
             foreground: root.foreground
             fontFamily: root.fontFamily
             iconComponent: Component {
@@ -314,7 +317,10 @@ Panel {
           DashboardSection {
             visible: count > 0
             title: "MY PULL REQUESTS"
-            count: github.myPullRequests.length
+            // The search is capped at one page, so the fetched list can be
+            // shorter than the real total. Show the total rather than implying
+            // the section is complete.
+            count: Math.max(github.myPullRequestsTotal, github.myPullRequests.length)
             model: root.sectionRows(github.myPullRequests, root.myPullsExpanded)
             expanded: root.myPullsExpanded
             openUrl: "https://github.com/pulls"
@@ -508,8 +514,8 @@ Panel {
       required property var modelData
       required property int index
       readonly property string checks: String(modelData.checks || "NONE")
-      readonly property bool broken: checks === "FAILURE" || checks === "ERROR"
-      readonly property bool running: checks === "PENDING" || checks === "EXPECTED"
+      readonly property bool broken: github.isBrokenCheck(checks)
+      readonly property bool running: github.isRunningCheck(checks)
       width: parent ? parent.width : 0
       rowKind: "mypull"
       rowIndex: index

--- a/Panel.qml
+++ b/Panel.qml
@@ -23,6 +23,7 @@ Panel {
   property int cursorIndex: 0
   property bool notificationsExpanded: false
   property bool reviewsExpanded: false
+  property bool myPullsExpanded: false
   property bool issuesExpanded: false
   property bool actionsExpanded: false
   property bool failuresExpanded: false
@@ -53,6 +54,7 @@ Panel {
     }
     add("notification", sectionRows(github.notifications, notificationsExpanded))
     add("review", sectionRows(github.reviewRequests, reviewsExpanded))
+    add("mypull", sectionRows(github.myPullRequests, myPullsExpanded))
     add("issue", sectionRows(github.assignedIssues, issuesExpanded))
     add("action", sectionRows(github.actions, actionsExpanded))
     add("failure", sectionRows(github.failedActions, failuresExpanded))
@@ -97,6 +99,14 @@ Panel {
   function setting(name, fallback) {
     var value = settings ? settings[name] : undefined
     return value === undefined || value === null ? fallback : value
+  }
+
+  function checkLabel(checks) {
+    if (checks === "SUCCESS") return "checks passing"
+    if (checks === "FAILURE") return "checks failing"
+    if (checks === "ERROR") return "checks errored"
+    if (checks === "PENDING" || checks === "EXPECTED") return "checks running"
+    return "no checks"
   }
 
   function openUrl(url) {
@@ -303,6 +313,17 @@ Panel {
 
           DashboardSection {
             visible: count > 0
+            title: "MY PULL REQUESTS"
+            count: github.myPullRequests.length
+            model: root.sectionRows(github.myPullRequests, root.myPullsExpanded)
+            expanded: root.myPullsExpanded
+            openUrl: "https://github.com/pulls"
+            onToggleExpanded: root.myPullsExpanded = !root.myPullsExpanded
+            delegateComponent: myPullRequestDelegate
+          }
+
+          DashboardSection {
+            visible: count > 0
             title: "ASSIGNED ISSUES"
             count: github.assignedIssues.length
             model: root.sectionRows(github.assignedIssues, root.issuesExpanded)
@@ -478,6 +499,29 @@ Panel {
       // review, so the row has to say which it is.
       detail: modelData.repository + (modelData.draft ? " · draft" : "") + " · review requested · " + root.relativeTime(modelData.updatedAt)
       url: modelData.url
+    }
+  }
+
+  Component {
+    id: myPullRequestDelegate
+    LinkRow {
+      required property var modelData
+      required property int index
+      readonly property string checks: String(modelData.checks || "NONE")
+      readonly property bool broken: checks === "FAILURE" || checks === "ERROR"
+      readonly property bool running: checks === "PENDING" || checks === "EXPECTED"
+      width: parent ? parent.width : 0
+      rowKind: "mypull"
+      rowIndex: index
+      rowId: String(modelData.id || modelData.url || index)
+      // A repository with no workflows reports no rollup at all, which the
+      // plain pull request glyph conveys without implying a pending run.
+      glyph: broken ? "󰅖" : (running ? "󰑮" : (checks === "SUCCESS" ? "󰄬" : ""))
+      title: modelData.title
+      detail: modelData.repository + " #" + modelData.number + (modelData.draft ? " · draft" : "") + " · " + root.checkLabel(checks) + " · " + root.relativeTime(modelData.updatedAt)
+      url: modelData.url
+      danger: broken
+      pulse: running
     }
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -522,7 +522,7 @@ Panel {
       rowId: String(modelData.id || modelData.url || index)
       // A repository with no workflows reports no rollup at all, which the
       // plain pull request glyph conveys without implying a pending run.
-      glyph: broken ? "󰅖" : (running ? "󰑮" : (checks === "SUCCESS" ? "󰄬" : ""))
+      glyph: broken ? "󰅖" : (running ? "󰑮" : (checks === "SUCCESS" ? "󰄬" : ""))
       title: modelData.title
       detail: modelData.repository + " #" + modelData.number + (modelData.draft ? " · draft" : "") + " · " + root.checkLabel(checks) + " · " + root.relativeTime(modelData.updatedAt)
       url: modelData.url
@@ -705,6 +705,7 @@ Panel {
         Text {
           Layout.fillWidth: true
           text: linkRow.title
+          textFormat: Text.PlainText
           color: root.foreground
           font.family: root.fontFamily
           font.pixelSize: Style.font.body
@@ -713,6 +714,7 @@ Panel {
         Text {
           Layout.fillWidth: true
           text: linkRow.detail
+          textFormat: Text.PlainText
           color: root.dim
           font.family: root.fontFamily
           font.pixelSize: Style.font.caption

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ From an existing checkout, validate and test the plugin:
 ```bash
 omarchy plugin validate .
 tests/helper-test.sh
+tests/panel-source-test.sh
 ```
 
 Install that checkout for local iteration:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The dashboard is ordered by urgency so the most actionable work appears first:
 
 - **Unread notifications** — open the related thread or mark it read in place
 - **Review requests** — see pull requests waiting on your review
+- **My pull requests** — track the pull requests you opened and the state of their checks
 - **Assigned issues** — keep track of open issues assigned to you
 - **Active GitHub Actions** — monitor queued, pending, requested, waiting, and running workflows
 - **Recent workflow failures** — jump directly to failed, timed-out, or action-required runs
@@ -165,6 +166,7 @@ The shell watches local plugin files, making QML iteration fast.
 - GraphQL retrieves every owned repository and exact aggregate counts.
 - REST retrieves notifications and workflow runs.
 - GitHub issue search retrieves review requests and assigned issues.
+- GraphQL search retrieves your authored pull requests together with the head commit's `statusCheckRollup`, so check state costs no extra request.
 - Status-specific, paginated Actions requests prevent busy repositories from hiding active runs.
 - Completed runs are server-bounded to the configured failure window.
 - Independent requests allow successful sections to remain available when one endpoint fails.

--- a/Service.qml
+++ b/Service.qml
@@ -17,6 +17,7 @@ Item {
     property var notifications: []
     property var reviewRequests: []
     property var assignedIssues: []
+    property var myPullRequests: []
     property var actions: []
     property var failedActions: []
     property var repositories: []
@@ -32,7 +33,13 @@ Item {
     readonly property int refreshIntervalSec: intSetting("refreshIntervalSec", 900, 60, 3600)
     readonly property int unreadCount: notifications.length
     readonly property int actionCount: actions.length
-    readonly property bool alarming: unreadCount > 0 || actionCount > 0 || reviewRequests.length > 0
+    // A broken check on your own pull request is the kind of thing the bar icon
+    // exists to surface, so it counts toward the alarming state.
+    readonly property int failingPullRequestCount: myPullRequests.filter(function(item) {
+        var checks = String(item.checks || "");
+        return checks === "FAILURE" || checks === "ERROR";
+    }).length
+    readonly property bool alarming: unreadCount > 0 || actionCount > 0 || reviewRequests.length > 0 || failingPullRequestCount > 0
 
     function setting(name, fallback) {
         var value = settings ? settings[name] : undefined;
@@ -97,6 +104,7 @@ Item {
             notifications = Array.isArray(data.notifications) ? data.notifications : [];
             reviewRequests = Array.isArray(data.reviewRequests) ? data.reviewRequests : [];
             assignedIssues = Array.isArray(data.assignedIssues) ? data.assignedIssues : [];
+            myPullRequests = Array.isArray(data.myPullRequests) ? data.myPullRequests : [];
             actions = Array.isArray(data.actions) ? data.actions : [];
             failedActions = Array.isArray(data.failedActions) ? data.failedActions : [];
             repositories = Array.isArray(data.repositories) ? data.repositories : [];

--- a/Service.qml
+++ b/Service.qml
@@ -18,6 +18,7 @@ Item {
     property var reviewRequests: []
     property var assignedIssues: []
     property var myPullRequests: []
+    property int myPullRequestsTotal: 0
     property var actions: []
     property var failedActions: []
     property var repositories: []
@@ -34,12 +35,25 @@ Item {
     readonly property int unreadCount: notifications.length
     readonly property int actionCount: actions.length
     // A broken check on your own pull request is the kind of thing the bar icon
-    // exists to surface, so it counts toward the alarming state.
+    // exists to surface, so it counts toward the alarming state. Drafts are
+    // excluded: a red check on work you have not offered up yet is expected,
+    // and it would leave the icon permanently lit.
     readonly property int failingPullRequestCount: myPullRequests.filter(function(item) {
-        var checks = String(item.checks || "");
-        return checks === "FAILURE" || checks === "ERROR";
+        return !item.draft && root.isBrokenCheck(item.checks);
     }).length
     readonly property bool alarming: unreadCount > 0 || actionCount > 0 || reviewRequests.length > 0 || failingPullRequestCount > 0
+
+    // StatusCheckRollup groupings live here so the alarming count, the row label
+    // and the row glyph cannot drift apart when a state is reclassified.
+    function isBrokenCheck(checks) {
+        var value = String(checks || "");
+        return value === "FAILURE" || value === "ERROR";
+    }
+
+    function isRunningCheck(checks) {
+        var value = String(checks || "");
+        return value === "PENDING" || value === "EXPECTED";
+    }
 
     function setting(name, fallback) {
         var value = settings ? settings[name] : undefined;
@@ -105,6 +119,7 @@ Item {
             reviewRequests = Array.isArray(data.reviewRequests) ? data.reviewRequests : [];
             assignedIssues = Array.isArray(data.assignedIssues) ? data.assignedIssues : [];
             myPullRequests = Array.isArray(data.myPullRequests) ? data.myPullRequests : [];
+            myPullRequestsTotal = Number(data.myPullRequestsTotal) || myPullRequests.length;
             actions = Array.isArray(data.actions) ? data.actions : [];
             failedActions = Array.isArray(data.failedActions) ? data.failedActions : [];
             repositories = Array.isArray(data.repositories) ? data.repositories : [];

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "0.2.2",
   "author": "Rob Zolkos",
   "license": "MIT",
-  "description": "A keyboard-friendly GitHub inbox for notifications, reviews, assigned issues, Actions, and owned repositories.",
+  "description": "A keyboard-friendly GitHub inbox for notifications, reviews, your own pull requests, assigned issues, Actions, and owned repositories.",
   "kinds": ["bar-widget"],
   "activation": "on-demand",
   "entryPoints": {
@@ -13,7 +13,7 @@
   },
   "barWidget": {
     "displayName": "GitHub",
-    "description": "Act on unread notifications and browse review requests, assigned issues, active or failed workflows, and repository metrics.",
+    "description": "Act on unread notifications and browse review requests, your authored pull requests with their check state, assigned issues, active or failed workflows, and repository metrics.",
     "category": "Development",
     "aliases": ["github", "octocat", "repos", "actions"],
     "allowMultiple": false,

--- a/omarchy-github-fetch
+++ b/omarchy-github-fetch
@@ -60,10 +60,10 @@ integer "$failed_limit" && ((failed_limit >= 1 && failed_limit <= 100)) || { ech
 [[ $action_scan == off || $action_scan == recent || $action_scan == all ]] || { echo "invalid --action-scan" >&2; exit 2; }
 
 emit_state() {
-  jq -n --arg state "$1" --arg message "$2" '{schemaVersion:1,state:$state,message:$message,login:"",fetchedAt:(now|todateiso8601),notifications:[],reviewRequests:[],assignedIssues:[],myPullRequests:[],actions:[],failedActions:[],repositories:[],warnings:[],rateLimit:null}'
+  jq -n --arg state "$1" --arg message "$2" '{schemaVersion:1,state:$state,message:$message,login:"",fetchedAt:(now|todateiso8601),notifications:[],reviewRequests:[],assignedIssues:[],myPullRequests:[],myPullRequestsTotal:0,actions:[],failedActions:[],repositories:[],warnings:[],rateLimit:null}'
 }
 
-command -v jq >/dev/null 2>&1 || { printf '%s\n' '{"schemaVersion":1,"state":"error","message":"jq is required.","notifications":[],"reviewRequests":[],"assignedIssues":[],"myPullRequests":[],"actions":[],"failedActions":[],"repositories":[],"warnings":[]}' ; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf '%s\n' '{"schemaVersion":1,"state":"error","message":"jq is required.","notifications":[],"reviewRequests":[],"assignedIssues":[],"myPullRequests":[],"myPullRequestsTotal":0,"actions":[],"failedActions":[],"repositories":[],"warnings":[]}' ; exit 0; }
 if [[ -n $mark_notification && ! $mark_notification =~ ^[0-9]+$ ]]; then
   jq -n --arg id "$mark_notification" '{state:"error",message:"Invalid notification thread id.",notificationId:$id}'
   exit 2
@@ -142,10 +142,14 @@ fetch_search assigned-issues "is%3Aopen+is%3Aissue+assignee%3A%40me$search_archi
 # Authored pull requests come from GraphQL rather than the search endpoint so
 # the head commit's check rollup arrives with them. The search API carries no
 # check state, which would otherwise cost one request per pull request.
-my_pr_search="is:open is:pr author:@me"
+# Sorted server-side so that if an account exceeds the page size, what survives
+# is the most recently touched work rather than an arbitrary slice. issueCount
+# carries the real total so the panel can say it is showing a subset.
+my_pr_search="is:open is:pr author:@me sort:updated-desc"
 bool "$include_archived" || my_pr_search+=" archived:false"
 printf '[]\n' >"$tmp/mypulls.json"
-if my_pulls=$(gh api graphql -f query='query($search:String!) { search(query:$search,type:ISSUE,first:50) { nodes { ... on PullRequest { number title url updatedAt isDraft repository { nameWithOwner } commits(last:1) { nodes { commit { statusCheckRollup { state } } } } } } } }' -F search="$my_pr_search" 2>"$tmp/mypulls.err"); then
+printf '0\n' >"$tmp/mypulls-total.json"
+if my_pulls=$(gh api graphql -f query='query($search:String!) { search(query:$search,type:ISSUE,first:50) { issueCount nodes { ... on PullRequest { number title url updatedAt isDraft repository { nameWithOwner } commits(last:1) { nodes { commit { statusCheckRollup { state } } } } } } } }' -F search="$my_pr_search" 2>"$tmp/mypulls.err"); then
   # A pull request with no configured workflows reports a null rollup, which is
   # a distinct state from pending and must not be rendered as one.
   printf '%s\n' "$my_pulls" | jq '[.data.search.nodes[] | select(.number != null) |
@@ -153,6 +157,7 @@ if my_pulls=$(gh api graphql -f query='query($search:String!) { search(query:$se
      repository:(.repository.nameWithOwner // ""),url:(.url // ""),updatedAt:(.updatedAt // ""),
      draft:(.isDraft // false),checks:(.commits.nodes[0].commit.statusCheckRollup.state // "NONE")}]
     | sort_by(.updatedAt) | reverse' >"$tmp/mypulls.json" 2>/dev/null || { printf '[]\n' >"$tmp/mypulls.json"; printf '%s\n' 'my-pull-requests: invalid API response' >>"$warnings"; }
+  printf '%s\n' "$my_pulls" | jq '.data.search.issueCount // 0' >"$tmp/mypulls-total.json" 2>/dev/null || printf '0\n' >"$tmp/mypulls-total.json"
 else
   api_error my-pull-requests "$tmp/mypulls.err"
 fi
@@ -209,4 +214,4 @@ repo_count=$(jq 'length' "$tmp/repos.json")
 if [[ $graphql_ok == false && $repo_count -eq 0 ]]; then state=error; message="GitHub repositories could not be loaded."; else state=ready; message=""; fi
 rate_remaining=$(jq -r '.remaining // 999999' "$tmp/rate.json")
 if { [[ $rate_remaining =~ ^[0-9]+$ ]] && ((rate_remaining<=0)); } || grep -qiE 'rate.?limit|secondary rate' "$warnings"; then state=rate-limited; message="GitHub API rate limit reached."; fi
-jq -n --arg state "$state" --arg message "$message" --arg login "${login:-}" --slurpfile notifications "$tmp/notifications.json" --slurpfile reviews "$tmp/reviews.json" --slurpfile issues "$tmp/issues.json" --slurpfile mypulls "$tmp/mypulls.json" --slurpfile actions "$tmp/actions.json" --slurpfile failed "$tmp/failed.json" --slurpfile repositories "$tmp/repos.json" --argjson warnings "$warnings_json" --slurpfile rate "$tmp/rate.json" '{schemaVersion:1,state:$state,message:$message,login:$login,fetchedAt:(now|todateiso8601),notifications:$notifications[0],reviewRequests:$reviews[0],assignedIssues:$issues[0],myPullRequests:$mypulls[0],actions:$actions[0],failedActions:$failed[0],repositories:$repositories[0],warnings:$warnings,rateLimit:$rate[0]}'
+jq -n --arg state "$state" --arg message "$message" --arg login "${login:-}" --slurpfile notifications "$tmp/notifications.json" --slurpfile reviews "$tmp/reviews.json" --slurpfile issues "$tmp/issues.json" --slurpfile mypulls "$tmp/mypulls.json" --slurpfile mypullstotal "$tmp/mypulls-total.json" --slurpfile actions "$tmp/actions.json" --slurpfile failed "$tmp/failed.json" --slurpfile repositories "$tmp/repos.json" --argjson warnings "$warnings_json" --slurpfile rate "$tmp/rate.json" '{schemaVersion:1,state:$state,message:$message,login:$login,fetchedAt:(now|todateiso8601),notifications:$notifications[0],reviewRequests:$reviews[0],assignedIssues:$issues[0],myPullRequests:$mypulls[0],myPullRequestsTotal:$mypullstotal[0],actions:$actions[0],failedActions:$failed[0],repositories:$repositories[0],warnings:$warnings,rateLimit:$rate[0]}'

--- a/omarchy-github-fetch
+++ b/omarchy-github-fetch
@@ -60,10 +60,10 @@ integer "$failed_limit" && ((failed_limit >= 1 && failed_limit <= 100)) || { ech
 [[ $action_scan == off || $action_scan == recent || $action_scan == all ]] || { echo "invalid --action-scan" >&2; exit 2; }
 
 emit_state() {
-  jq -n --arg state "$1" --arg message "$2" '{schemaVersion:1,state:$state,message:$message,login:"",fetchedAt:(now|todateiso8601),notifications:[],reviewRequests:[],assignedIssues:[],actions:[],failedActions:[],repositories:[],warnings:[],rateLimit:null}'
+  jq -n --arg state "$1" --arg message "$2" '{schemaVersion:1,state:$state,message:$message,login:"",fetchedAt:(now|todateiso8601),notifications:[],reviewRequests:[],assignedIssues:[],myPullRequests:[],actions:[],failedActions:[],repositories:[],warnings:[],rateLimit:null}'
 }
 
-command -v jq >/dev/null 2>&1 || { printf '%s\n' '{"schemaVersion":1,"state":"error","message":"jq is required.","notifications":[],"reviewRequests":[],"assignedIssues":[],"actions":[],"failedActions":[],"repositories":[],"warnings":[]}' ; exit 0; }
+command -v jq >/dev/null 2>&1 || { printf '%s\n' '{"schemaVersion":1,"state":"error","message":"jq is required.","notifications":[],"reviewRequests":[],"assignedIssues":[],"myPullRequests":[],"actions":[],"failedActions":[],"repositories":[],"warnings":[]}' ; exit 0; }
 if [[ -n $mark_notification && ! $mark_notification =~ ^[0-9]+$ ]]; then
   jq -n --arg id "$mark_notification" '{state:"error",message:"Invalid notification thread id.",notificationId:$id}'
   exit 2
@@ -139,6 +139,24 @@ if bool "$include_draft_reviews"; then search_draft=""; else search_draft="+draf
 fetch_search review-requests "is%3Aopen+is%3Apr+review-requested%3A%40me$search_draft$search_archived" "$tmp/reviews.json"
 fetch_search assigned-issues "is%3Aopen+is%3Aissue+assignee%3A%40me$search_archived" "$tmp/issues.json"
 
+# Authored pull requests come from GraphQL rather than the search endpoint so
+# the head commit's check rollup arrives with them. The search API carries no
+# check state, which would otherwise cost one request per pull request.
+my_pr_search="is:open is:pr author:@me"
+bool "$include_archived" || my_pr_search+=" archived:false"
+printf '[]\n' >"$tmp/mypulls.json"
+if my_pulls=$(gh api graphql -f query='query($search:String!) { search(query:$search,type:ISSUE,first:50) { nodes { ... on PullRequest { number title url updatedAt isDraft repository { nameWithOwner } commits(last:1) { nodes { commit { statusCheckRollup { state } } } } } } } }' -F search="$my_pr_search" 2>"$tmp/mypulls.err"); then
+  # A pull request with no configured workflows reports a null rollup, which is
+  # a distinct state from pending and must not be rendered as one.
+  printf '%s\n' "$my_pulls" | jq '[.data.search.nodes[] | select(.number != null) |
+    {id:((.repository.nameWithOwner // "") + "#" + (.number|tostring)),number,title:(.title // ""),
+     repository:(.repository.nameWithOwner // ""),url:(.url // ""),updatedAt:(.updatedAt // ""),
+     draft:(.isDraft // false),checks:(.commits.nodes[0].commit.statusCheckRollup.state // "NONE")}]
+    | sort_by(.updatedAt) | reverse' >"$tmp/mypulls.json" 2>/dev/null || { printf '[]\n' >"$tmp/mypulls.json"; printf '%s\n' 'my-pull-requests: invalid API response' >>"$warnings"; }
+else
+  api_error my-pull-requests "$tmp/mypulls.err"
+fi
+
 cursor=null
 printf '[]\n' >"$tmp/repos.json"
 graphql_ok=true
@@ -191,4 +209,4 @@ repo_count=$(jq 'length' "$tmp/repos.json")
 if [[ $graphql_ok == false && $repo_count -eq 0 ]]; then state=error; message="GitHub repositories could not be loaded."; else state=ready; message=""; fi
 rate_remaining=$(jq -r '.remaining // 999999' "$tmp/rate.json")
 if { [[ $rate_remaining =~ ^[0-9]+$ ]] && ((rate_remaining<=0)); } || grep -qiE 'rate.?limit|secondary rate' "$warnings"; then state=rate-limited; message="GitHub API rate limit reached."; fi
-jq -n --arg state "$state" --arg message "$message" --arg login "${login:-}" --slurpfile notifications "$tmp/notifications.json" --slurpfile reviews "$tmp/reviews.json" --slurpfile issues "$tmp/issues.json" --slurpfile actions "$tmp/actions.json" --slurpfile failed "$tmp/failed.json" --slurpfile repositories "$tmp/repos.json" --argjson warnings "$warnings_json" --slurpfile rate "$tmp/rate.json" '{schemaVersion:1,state:$state,message:$message,login:$login,fetchedAt:(now|todateiso8601),notifications:$notifications[0],reviewRequests:$reviews[0],assignedIssues:$issues[0],actions:$actions[0],failedActions:$failed[0],repositories:$repositories[0],warnings:$warnings,rateLimit:$rate[0]}'
+jq -n --arg state "$state" --arg message "$message" --arg login "${login:-}" --slurpfile notifications "$tmp/notifications.json" --slurpfile reviews "$tmp/reviews.json" --slurpfile issues "$tmp/issues.json" --slurpfile mypulls "$tmp/mypulls.json" --slurpfile actions "$tmp/actions.json" --slurpfile failed "$tmp/failed.json" --slurpfile repositories "$tmp/repos.json" --argjson warnings "$warnings_json" --slurpfile rate "$tmp/rate.json" '{schemaVersion:1,state:$state,message:$message,login:$login,fetchedAt:(now|todateiso8601),notifications:$notifications[0],reviewRequests:$reviews[0],assignedIssues:$issues[0],myPullRequests:$mypulls[0],actions:$actions[0],failedActions:$failed[0],repositories:$repositories[0],warnings:$warnings,rateLimit:$rate[0]}'

--- a/tests/helper-test.sh
+++ b/tests/helper-test.sh
@@ -43,7 +43,7 @@ if [[ $1 == api && $2 == graphql ]]; then
     # The second node carries no rollup, which must land as NONE rather than
     # being conflated with a pending run.
     cat <<'JSON'
-{"data":{"search":{"nodes":[{"number":7,"title":"Ship it","url":"https://github.com/octocat/hello/pull/7","updatedAt":"2026-01-05T00:00:00Z","isDraft":false,"repository":{"nameWithOwner":"octocat/hello"},"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"FAILURE"}}}]}},{"number":9,"title":"No CI here","url":"https://github.com/octocat/quiet/pull/9","updatedAt":"2026-01-04T00:00:00Z","isDraft":true,"repository":{"nameWithOwner":"octocat/quiet"},"commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]}}]}}}
+{"data":{"search":{"issueCount":2,"nodes":[{"number":7,"title":"Ship it","url":"https://github.com/octocat/hello/pull/7","updatedAt":"2026-01-05T00:00:00Z","isDraft":false,"repository":{"nameWithOwner":"octocat/hello"},"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"FAILURE"}}}]}},{"number":9,"title":"No CI here","url":"https://github.com/octocat/quiet/pull/9","updatedAt":"2026-01-04T00:00:00Z","isDraft":true,"repository":{"nameWithOwner":"octocat/quiet"},"commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]}}]}}}
 JSON
     exit 0
   fi
@@ -104,16 +104,16 @@ assert_jq '(.actions|length == 1) and (.failedActions|length == 1)' "$out" "acti
 assert_jq '.rateLimit.remaining == 4999 and (.warnings|length) == 0' "$out" "rate limit and warnings"
 assert_jq '(.myPullRequests|length == 2) and (.myPullRequests[0].id == "octocat/hello#7") and (.myPullRequests[0].checks == "FAILURE")' "$out" "authored pull requests with check rollup"
 assert_jq '(.myPullRequests[1].checks == "NONE") and (.myPullRequests[1].draft == true)' "$out" "missing rollup falls back to NONE"
+assert_jq '.myPullRequestsTotal == 2' "$out" "authored pull request total reported"
+grep -q 'author:@me.*sort:updated-desc' "$GH_TEST_LOG" || fail "authored pull request search was not server sorted"
 grep -q 'author:@me.*archived:false' "$GH_TEST_LOG" || fail "authored pull request search was not archive filtered"
-out_archived=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan off --include-archived true)
-assert_jq '.myPullRequests|length == 2' "$out_archived" "authored pull requests survive the archived setting"
 grep -q -- '--paginate.*status=queued' "$GH_TEST_LOG" || fail "queued Actions request was not paginated"
 grep -q 'status=completed.*created=%3E%3D' "$GH_TEST_LOG" || fail "completed Actions request was not date bounded"
 grep -q 'review-requested%3A%40me+draft%3Afalse+archived%3Afalse' "$GH_TEST_LOG" || fail "review request search was not draft and archive filtered"
 grep -q 'assignee%3A%40me+archived%3Afalse' "$GH_TEST_LOG" || fail "assigned issue search was not archive filtered"
 : >"$GH_TEST_LOG"
-out_archived=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan off --include-archived-reviews true)
-assert_jq '(.reviewRequests|length == 1) and (.assignedIssues|length == 1)' "$out_archived" "searches still return with archived included"
+out_archived_reviews=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan off --include-archived-reviews true)
+assert_jq '(.reviewRequests|length == 1) and (.assignedIssues|length == 1)' "$out_archived_reviews" "searches still return with archived included"
 if grep -q 'archived%3Afalse' "$GH_TEST_LOG"; then fail "archived filter applied despite --include-archived-reviews true"; fi
 # The draft exclusion has its own setting, so it must survive the archived one.
 grep -q 'draft%3Afalse' "$GH_TEST_LOG" || fail "draft exclusion dropped when archived repositories are included"
@@ -122,6 +122,12 @@ out_drafts=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan off --include-draft-r
 assert_jq '.reviewRequests|length == 1' "$out_drafts" "review requests still return with drafts included"
 if grep -q 'draft%3Afalse' "$GH_TEST_LOG"; then fail "draft filter applied despite --include-draft-reviews true"; fi
 grep -q 'archived%3Afalse' "$GH_TEST_LOG" || fail "archived filter dropped when drafts are included"
+# The repository-list archive setting independently controls authored PRs.
+: >"$GH_TEST_LOG"
+out_archived=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan off --include-archived true)
+assert_jq '.myPullRequests|length == 2' "$out_archived" "authored pull requests survive the archived setting"
+grep -q 'author:@me' "$GH_TEST_LOG" || fail "authored pull request search did not run"
+if grep -q 'archived:false' "$GH_TEST_LOG"; then fail "archived filter applied despite --include-archived true"; fi
 mark=$(PATH="$sandbox:$PATH" "$HELPER" --mark-notification-read 123)
 assert_jq '.state == "ready" and .notificationId == "123"' "$mark" "mark notification read"
 

--- a/tests/helper-test.sh
+++ b/tests/helper-test.sh
@@ -38,6 +38,15 @@ if [[ $1 == api && $2 == --method && $3 == PATCH ]]; then
   printf '%s\n' '{}'; exit 0
 fi
 if [[ $1 == api && $2 == graphql ]]; then
+  printf '%s\n' "$*" >>"$GH_TEST_LOG"
+  if [[ $* == *author:@me* ]]; then
+    # The second node carries no rollup, which must land as NONE rather than
+    # being conflated with a pending run.
+    cat <<'JSON'
+{"data":{"search":{"nodes":[{"number":7,"title":"Ship it","url":"https://github.com/octocat/hello/pull/7","updatedAt":"2026-01-05T00:00:00Z","isDraft":false,"repository":{"nameWithOwner":"octocat/hello"},"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"FAILURE"}}}]}},{"number":9,"title":"No CI here","url":"https://github.com/octocat/quiet/pull/9","updatedAt":"2026-01-04T00:00:00Z","isDraft":true,"repository":{"nameWithOwner":"octocat/quiet"},"commits":{"nodes":[{"commit":{"statusCheckRollup":null}}]}}]}}}
+JSON
+    exit 0
+  fi
   cat <<'JSON'
 {"data":{"viewer":{"login":"octocat","repositories":{"nodes":[{"name":"hello","nameWithOwner":"octocat/hello","url":"https://github.com/octocat/hello","isArchived":false,"isFork":false,"stargazerCount":42,"updatedAt":"2026-01-01T00:00:00Z","issues":{"totalCount":3},"pullRequests":{"totalCount":2}},{"name":"old","nameWithOwner":"octocat/old","url":"https://github.com/octocat/old","isArchived":true,"isFork":false,"stargazerCount":1,"updatedAt":"2020-01-01T00:00:00Z","issues":{"totalCount":0},"pullRequests":{"totalCount":0}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}},"rateLimit":{"remaining":4999,"resetAt":"2026-01-01T01:00:00Z","cost":1}}}
 JSON
@@ -93,6 +102,11 @@ assert_jq '.reviewRequests|length == 1 and .[0].repository == "octocat/hello"' "
 assert_jq '(.assignedIssues|length == 1) and (.assignedIssues[0].url|endswith("/issues/8"))' "$out" "assigned issues"
 assert_jq '(.actions|length == 1) and (.failedActions|length == 1)' "$out" "active and failed actions separated"
 assert_jq '.rateLimit.remaining == 4999 and (.warnings|length) == 0' "$out" "rate limit and warnings"
+assert_jq '(.myPullRequests|length == 2) and (.myPullRequests[0].id == "octocat/hello#7") and (.myPullRequests[0].checks == "FAILURE")' "$out" "authored pull requests with check rollup"
+assert_jq '(.myPullRequests[1].checks == "NONE") and (.myPullRequests[1].draft == true)' "$out" "missing rollup falls back to NONE"
+grep -q 'author:@me.*archived:false' "$GH_TEST_LOG" || fail "authored pull request search was not archive filtered"
+out_archived=$(PATH="$sandbox:$PATH" "$HELPER" --action-scan off --include-archived true)
+assert_jq '.myPullRequests|length == 2' "$out_archived" "authored pull requests survive the archived setting"
 grep -q -- '--paginate.*status=queued' "$GH_TEST_LOG" || fail "queued Actions request was not paginated"
 grep -q 'status=completed.*created=%3E%3D' "$GH_TEST_LOG" || fail "completed Actions request was not date bounded"
 grep -q 'review-requested%3A%40me+draft%3Afalse+archived%3Afalse' "$GH_TEST_LOG" || fail "review request search was not draft and archive filtered"

--- a/tests/panel-source-test.sh
+++ b/tests/panel-source-test.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+PANEL="$ROOT/Panel.qml"
+PANEL_SOURCE=$(<"$PANEL")
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+assert_contains() {
+  [[ $PANEL_SOURCE == *"$1"* ]] || fail "$2"
+}
+
+assert_contains 'glyph: broken ? "󰅖" : (running ? "󰑮" : (checks === "SUCCESS" ? "󰄬" : ""))' \
+  "authored pull requests without checks do not use the pull request glyph"
+assert_contains $'text: linkRow.title\n          textFormat: Text.PlainText' \
+  "row titles are not forced to plain text"
+assert_contains $'text: linkRow.detail\n          textFormat: Text.PlainText' \
+  "row details are not forced to plain text"
+
+echo "panel source tests passed"


### PR DESCRIPTION
The dashboard shows pull requests waiting on your review but never the ones you opened, so a broken build on your own work stays invisible until GitHub happens to send a notification about it.

This adds a **My pull requests** section listing your open pull requests with the state of their checks, across every repository and organisation.

## Why GraphQL rather than the search endpoint

The REST search API carries no check state, so the section would cost one extra request per pull request. `search(type: ISSUE)` returns the pull requests and the head commit's `statusCheckRollup` in the same request.

A repository with no configured workflows reports a null rollup. That is rendered as its own state rather than as a pending run, which would otherwise leave the row pulsing forever on repositories that have no CI at all.

## Bar indicator

`alarming` gains a fourth term: a failing check on a pull request you authored. That is a behaviour change to an always-visible feature, so calling it out explicitly.

The reasoning is that a broken build on your own open work is exactly what the indicator exists for, and there is no other surface that tells you. Drafts are excluded from the count, since a red check on work you have not offered for review yet is expected and would keep the icon permanently lit. The panel's summary line gained the same term, so it never reads all zeroes while the icon is lit.

If you would rather the indicator stayed as it was, the last commit is easy to drop and the section still stands on its own.

## Scope of the search

The query is one page of 50, sorted `updated-desc` server-side, and the section header reports the real `issueCount` rather than the number fetched. So an account above that size shows its most recently touched work and says how many exist, instead of showing an arbitrary slice that looks complete.

It carries `archived:false` under the existing **Include archived repositories** setting. That leaves it inconsistent with the two sibling searches on `main`, which apply no archived filtering at all. #2 brings those in line; if that one lands first this is already consistent, and if it does not, say the word and I will drop the qualifier here instead.

## Testing

`bash tests/helper-test.sh` passes. New cases cover the rollup mapping, the null-rollup fallback, the reported total, the server-side sort, and that the archived qualifier is applied and dropped by its own setting.

Exercised against a live account with open pull requests across personal repositories and two organisations, including one with a failing build and several with no CI configured.

## Merge order

This branch is based directly on `main` and stands alone. It overlaps PR #1 on `Panel.qml`, `Service.qml`, and `tests/helper-test.sh`, so whichever merges second needs a rebase. Happy to do that in whatever order suits you.
