### PR TITLE
Add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends jq
+
+      - name: Validate manifest
+        run: jq empty manifest.json
+
+      - name: Run helper tests
+        run: tests/helper-test.sh

--- a/omarchy-github-fetch
+++ b/omarchy-github-fetch
@@ -54,12 +54,15 @@ emit_state() {
   jq -n --arg state "$1" --arg message "$2" '{schemaVersion:1,state:$state,message:$message,login:"",fetchedAt:(now|todateiso8601),notifications:[],reviewRequests:[],assignedIssues:[],actions:[],failedActions:[],repositories:[],warnings:[],rateLimit:null}'
 }
 
-command -v gh >/dev/null 2>&1 || { emit_state gh-not-installed "GitHub CLI is not installed or not on PATH."; exit 0; }
 command -v jq >/dev/null 2>&1 || { printf '%s\n' '{"schemaVersion":1,"state":"error","message":"jq is required.","notifications":[],"reviewRequests":[],"assignedIssues":[],"actions":[],"failedActions":[],"repositories":[],"warnings":[]}' ; exit 0; }
+if [[ -n $mark_notification && ! $mark_notification =~ ^[0-9]+$ ]]; then
+  jq -n --arg id "$mark_notification" '{state:"error",message:"Invalid notification thread id.",notificationId:$id}'
+  exit 2
+fi
+command -v gh >/dev/null 2>&1 || { emit_state gh-not-installed "GitHub CLI is not installed or not on PATH."; exit 0; }
 gh auth status -h github.com >/dev/null 2>&1 || { emit_state logged-out "Sign in with gh auth login to load GitHub data."; exit 0; }
 
 if [[ -n $mark_notification ]]; then
-  [[ $mark_notification =~ ^[0-9]+$ ]] || { jq -n --arg id "$mark_notification" '{state:"error",message:"Invalid notification thread id.",notificationId:$id}'; exit 2; }
   if error=$(mktemp); then
     if gh api --method PATCH "/notifications/threads/$mark_notification" >/dev/null 2>"$error"; then
       rm -f "$error"


### PR DESCRIPTION
Adds the repository's first GitHub Actions workflow so contributor pull requests receive fast, repeatable validation without requiring GitHub credentials or an Omarchy installation.

## What changed

- Run CI for pull requests and pushes to `main`
- Validate `manifest.json` with `jq`
- Run the existing mocked helper test suite
- Use read-only repository permissions
- Cancel superseded runs for the same branch or pull request
- Validate notification IDs before GitHub authentication so argument tests remain deterministic in unauthenticated environments

## Validation

```text
$ tests/helper-test.sh
helper tests passed

$ GH_CONFIG_DIR="$(mktemp -d)" tests/helper-test.sh
helper tests passed

$ jq empty manifest.json
# passed

$ git diff --check
# passed
```

## Scope

This validates the manifest and shell helper behavior. QML UI behavior and `omarchy plugin validate` remain local checks because the hosted runner does not include Omarchy.
