### PR TITLE
Upgrade checkout action to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends jq


### PR DESCRIPTION
Updates the CI workflow to use `actions/checkout@v5`, removing the Node.js 20 deprecation warning while preserving the existing validation behavior.

## Validation

- `tests/helper-test.sh` — passed
- `tests/panel-source-test.sh` — passed
- `jq empty manifest.json` — passed
- `git diff --check` — passed