### PR TITLE
Open links in a webapp window instead of a browser tab

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -113,7 +113,14 @@ Panel {
   function openUrl(url) {
     var value = String(url || "")
     if (value === "") return
-    Quickshell.execDetached(["omarchy-launch-webapp", value])
+    var behavior = setting("linkBehavior", "Browser tab")
+    if (behavior === "Web app window") {
+      Quickshell.execDetached(["omarchy-launch-webapp", value])
+    } else if (behavior === "Web app window (focus existing)") {
+      Quickshell.execDetached(["omarchy-launch-or-focus-webapp", "chrome-github", value])
+    } else {
+      Quickshell.execDetached(["omarchy-launch-browser", value])
+    }
     close()
   }
 

--- a/Panel.qml
+++ b/Panel.qml
@@ -117,7 +117,7 @@ Panel {
     if (behavior === "Web app window") {
       Quickshell.execDetached(["omarchy-launch-webapp", value])
     } else if (behavior === "Web app window (reuse)") {
-      var opener = Qt.resolvedUrl("omarchy-github-open").toString().replace(/^file:\/\//, "")
+      var opener = decodeURIComponent(Qt.resolvedUrl("omarchy-github-open").toString().replace(/^file:\/\//, ""))
       Quickshell.execDetached([opener, value])
     } else {
       Quickshell.execDetached(["omarchy-launch-browser", value])

--- a/Panel.qml
+++ b/Panel.qml
@@ -116,8 +116,9 @@ Panel {
     var behavior = setting("linkBehavior", "Browser tab")
     if (behavior === "Web app window") {
       Quickshell.execDetached(["omarchy-launch-webapp", value])
-    } else if (behavior === "Web app window (focus existing)") {
-      Quickshell.execDetached(["omarchy-launch-or-focus-webapp", "chrome-github", value])
+    } else if (behavior === "Web app window (reuse)") {
+      var opener = Qt.resolvedUrl("omarchy-github-open").toString().replace(/^file:\/\//, "")
+      Quickshell.execDetached([opener, value])
     } else {
       Quickshell.execDetached(["omarchy-launch-browser", value])
     }

--- a/Panel.qml
+++ b/Panel.qml
@@ -113,7 +113,7 @@ Panel {
   function openUrl(url) {
     var value = String(url || "")
     if (value === "") return
-    Quickshell.execDetached(["omarchy-launch-browser", value])
+    Quickshell.execDetached(["omarchy-launch-webapp", value])
     close()
   }
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Configure the widget through Omarchy's bar widget settings. Existing installatio
 | Setting | Default |
 | --- | --- |
 | Refresh interval | 900 seconds (15 minutes) |
+| Open links | **Browser tab** |
 | Include archived repositories | Off |
 | Include forks | Off |
 | Repository scope | **Owned** |
@@ -150,6 +151,8 @@ Configure the widget through Omarchy's bar widget settings. Existing installatio
 **Repository scope** controls both the repository dashboard and the candidate repositories for Actions scanning. **Owned and organizations** is opt-in. With the default **Recent repositories** scan, Actions requests remain capped to the 15 most recently updated repositories in that wider scope.
 
 **All repositories** is also opt-in and starts six paginated Actions request streams per repository on every refresh. Combining it with **Owned and organizations** can consume substantial GitHub API capacity in large organizations. Use **Recent repositories** or **Off** for a bounded scan, and increase the refresh interval when broader monitoring is required.
+
+**Open links** controls where notifications, pull requests, issues, workflow runs, and repositories open. The default **Browser tab** keeps the historical behavior in any browser. **Web app window** opens each link in a dedicated Chromium app window via `omarchy-launch-webapp`, and **Web app window (focus existing)** additionally reuses the running GitHub web app window instead of accumulating new ones. Both web app modes require a Chromium-based default browser; with any other default browser they fall back to launching Chromium directly.
 
 Set these options from the command line after installing the plugin:
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Configure the widget through Omarchy's bar widget settings. Existing installatio
 
 **All repositories** is also opt-in and starts six paginated Actions request streams per repository on every refresh. Combining it with **Owned and organizations** can consume substantial GitHub API capacity in large organizations. Use **Recent repositories** or **Off** for a bounded scan, and increase the refresh interval when broader monitoring is required.
 
-**Open links** controls where notifications, pull requests, issues, workflow runs, and repositories open. The default **Browser tab** keeps the historical behavior in any browser. **Web app window** opens each link in a dedicated Chromium app window via `omarchy-launch-webapp`, and **Web app window (focus existing)** additionally reuses the running GitHub web app window instead of accumulating new ones. Both web app modes require a Chromium-based default browser; with any other default browser they fall back to launching Chromium directly.
+**Open links** controls where notifications, pull requests, issues, workflow runs, and repositories open. The default **Browser tab** keeps the historical behavior in any browser. **Web app window** opens each link in a dedicated Chromium app window via `omarchy-launch-webapp`, and **Web app window (reuse)** keeps a single web app window: any open GitHub web app window is closed and the clicked link opens in a fresh one. Both web app modes require a Chromium-based default browser; with any other default browser they fall back to launching Chromium directly.
 
 Set these options from the command line after installing the plugin:
 

--- a/Service.qml
+++ b/Service.qml
@@ -103,7 +103,7 @@ Item {
     }
 
     function helperPath() {
-        return Qt.resolvedUrl("omarchy-github-fetch").toString().replace(/^file:\/\//, "");
+        return decodeURIComponent(Qt.resolvedUrl("omarchy-github-fetch").toString().replace(/^file:\/\//, ""));
     }
 
     function command() {

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,7 @@
     "defaultSection": "right",
     "defaults": {
       "refreshIntervalSec": 900,
+      "linkBehavior": "Browser tab",
       "includeArchived": false,
       "includeForks": false,
       "repositoryScope": "Owned",
@@ -34,6 +35,7 @@
     },
     "schema": [
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 60, "max": 3600, "step": 60, "defaultValue": 900 },
+      { "key": "linkBehavior", "type": "enum", "label": "Open links", "options": ["Browser tab", "Web app window", "Web app window (focus existing)"], "defaultValue": "Browser tab", "description": "Open links in a browser tab, in a dedicated web app window, or in an existing web app window when one is already open. The web app modes require a Chromium-based default browser." },
       { "key": "includeArchived", "type": "boolean", "label": "Include archived repositories", "defaultValue": false },
       { "key": "includeForks", "type": "boolean", "label": "Include forked repositories", "defaultValue": false },
       { "key": "repositoryScope", "type": "enum", "label": "Repository scope", "options": ["Owned", "Owned and organizations"], "defaultValue": "Owned", "description": "List only repositories you own, or include organization repositories. This scope also supplies candidates for Actions scanning." },

--- a/manifest.json
+++ b/manifest.json
@@ -35,7 +35,7 @@
     },
     "schema": [
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 60, "max": 3600, "step": 60, "defaultValue": 900 },
-      { "key": "linkBehavior", "type": "enum", "label": "Open links", "options": ["Browser tab", "Web app window", "Web app window (focus existing)"], "defaultValue": "Browser tab", "description": "Open links in a browser tab, in a dedicated web app window, or in an existing web app window when one is already open. The web app modes require a Chromium-based default browser." },
+      { "key": "linkBehavior", "type": "enum", "label": "Open links", "options": ["Browser tab", "Web app window", "Web app window (reuse)"], "defaultValue": "Browser tab", "description": "Open links in a browser tab, in a dedicated web app window, or reusing a single web app window that always shows the clicked link. The web app modes require Hyprland and a Chromium-based default browser." },
       { "key": "includeArchived", "type": "boolean", "label": "Include archived repositories", "defaultValue": false },
       { "key": "includeForks", "type": "boolean", "label": "Include forked repositories", "defaultValue": false },
       { "key": "repositoryScope", "type": "enum", "label": "Repository scope", "options": ["Owned", "Owned and organizations"], "defaultValue": "Owned", "description": "List only repositories you own, or include organization repositories. This scope also supplies candidates for Actions scanning." },

--- a/omarchy-github-open
+++ b/omarchy-github-open
@@ -10,7 +10,7 @@ if [[ -z $url ]]; then
   exit 0
 fi
 
-pattern='chrome-github\.com__'
+pattern='github\.com__'
 
 addresses=$(hyprctl clients -j | jq -r --arg p "$pattern" '.[] | select(.class | test($p)) | .address')
 

--- a/omarchy-github-open
+++ b/omarchy-github-open
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Reuse a single GitHub web app window: close any open GitHub web app
+# windows, then open url in a fresh one so the window always shows the
+# link that was clicked.
+# omarchy:args=<url>
+
+url="$1"
+
+if [[ -z $url ]]; then
+  exit 0
+fi
+
+pattern='chrome-github\.com__'
+
+addresses=$(hyprctl clients -j | jq -r --arg p "$pattern" '.[] | select(.class | test($p)) | .address')
+
+while IFS= read -r addr; do
+  [[ -n $addr ]] || continue
+  hyprctl dispatch "hl.dsp.window.close({ window = \"address:$addr\" })" >/dev/null 2>&1 ||
+    hyprctl dispatch "closewindow address:$addr" >/dev/null 2>&1
+done <<<"$addresses"
+
+sleep 0.25
+
+exec omarchy-launch-webapp "$url"


### PR DESCRIPTION
## Summary

All panel links funnel through `openUrl()` in `Panel.qml`, which launched `omarchy-launch-browser`. This switches it to Omarchy's `omarchy-launch-webapp`, so notifications, review requests, pull requests, assigned issues, workflow runs, and repositories open in a dedicated app-mode window (`chromium --app=<url>`) instead of a new browser tab.

## Notes

- `omarchy-launch-webapp` ships with Omarchy and targets Chromium-based default browsers (falling back to chromium.desktop). On systems whose default browser is not Chromium-based, behavior would differ — happy to gate this behind a bar-widget setting if you would rather keep browser-tab behavior for those setups.
- Verified with `omarchy plugin validate .` and all bundled tests (`helper-test.sh`, `panel-source-test.sh`, `service-source-test.sh`).