### PR TITLE
Add setting to always keep the bar icon unlit

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Configure the widget through Omarchy's bar widget settings. Existing installatio
 | Actions request concurrency | 6 |
 | Failed Actions window | 7 days |
 | Maximum failed Actions | 20 |
+| Keep the bar icon unlit | Off |
 
 **Repository scope** controls both the repository dashboard and the candidate repositories for Actions scanning. **Owned and organizations** is opt-in. With the default **Recent repositories** scan, Actions requests remain capped to the 15 most recently updated repositories in that wider scope.
 

--- a/Service.qml
+++ b/Service.qml
@@ -48,7 +48,8 @@ Item {
     readonly property int failingPullRequestCount: myPullRequests.filter(function(item) {
         return !item.draft && root.isBrokenCheck(item.checks);
     }).length
-    readonly property bool alarming: unreadCount > 0 || actionCount > 0 || reviewRequests.length > 0 || failingPullRequestCount > 0
+    readonly property bool iconAlwaysUnlit: boolSetting("iconAlwaysUnlit", false)
+    readonly property bool alarming: !iconAlwaysUnlit && (unreadCount > 0 || actionCount > 0 || reviewRequests.length > 0 || failingPullRequestCount > 0)
 
     // StatusCheckRollup groupings live here so the alarming count, the row label
     // and the row glyph cannot drift apart when a state is reclassified.

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,8 @@
       "actionScanRepoLimit": 15,
       "actionScanConcurrency": 6,
       "failedActionDays": 7,
-      "failedActionLimit": 20
+      "failedActionLimit": 20,
+      "iconAlwaysUnlit": false
     },
     "schema": [
       { "key": "refreshIntervalSec", "type": "integer", "label": "Refresh interval (seconds)", "min": 60, "max": 3600, "step": 60, "defaultValue": 900 },
@@ -44,7 +45,8 @@
       { "key": "actionScanRepoLimit", "type": "integer", "label": "Recent repository scan limit", "min": 5, "max": 200, "step": 5, "defaultValue": 15 },
       { "key": "actionScanConcurrency", "type": "integer", "label": "Actions scan concurrency", "min": 1, "max": 12, "step": 1, "defaultValue": 6 },
       { "key": "failedActionDays", "type": "integer", "label": "Failed Actions window (days)", "min": 1, "max": 30, "step": 1, "defaultValue": 7 },
-      { "key": "failedActionLimit", "type": "integer", "label": "Maximum failed Actions", "min": 1, "max": 100, "step": 5, "defaultValue": 20 }
+      { "key": "failedActionLimit", "type": "integer", "label": "Maximum failed Actions", "min": 1, "max": 100, "step": 5, "defaultValue": 20 },
+      { "key": "iconAlwaysUnlit", "type": "boolean", "label": "Keep the bar icon unlit", "defaultValue": false, "description": "Keep the bar icon unlit regardless of unread notifications, active actions, review requests, or failing PR checks. Counts and rows still populate the panel as usual." }
     ]
   }
 }


### PR DESCRIPTION
## What

Adds an `iconAlwaysUnlit` boolean setting (default: `false`, matching current behavior). When on, the bar icon stays unlit regardless of unread notifications, active actions, review requests, or failing PR checks.

<img width="675" height="440" alt="screenshot-2026-08-21_08-20-47" src="https://github.com/user-attachments/assets/0d1fb19c-99c0-46bc-9704-b8098212998d" />

## Why

There appears to be no setting for this currently, and some folks (myself included) would rather keep their bar muted and monochromatic.